### PR TITLE
Fix Node 22 Docker builds

### DIFF
--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -3,7 +3,7 @@
 # This allows access to both apps/freedom-node/ and apps/web/dist/
 
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -28,12 +28,13 @@ RUN npx tsc --project /app/packages/fl/tsconfig.json \
 COPY apps/freedom-node/src ./src
 COPY apps/freedom-node/scripts ./scripts
 COPY apps/freedom-node/tsconfig.json ./
+COPY scripts/check-node.mjs /app/scripts/check-node.mjs
 
 # Build TypeScript
 RUN npm run build
 
 # Production stage
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/apps/freedom-node/Dockerfile
+++ b/apps/freedom-node/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -22,6 +22,7 @@ RUN npx tsc --project /app/packages/fl/tsconfig.json \
 
 # Copy server source files
 COPY apps/freedom-node/ ./
+COPY scripts/check-node.mjs /app/scripts/check-node.mjs
 
 # Copy frontend build from monorepo
 COPY apps/web/dist /app/apps/web/dist
@@ -30,7 +31,7 @@ COPY apps/web/dist /app/apps/web/dist
 RUN npm run build
 
 # Production stage
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## What changed

- Updates the Freedom Node builder and runtime images from Node 20 to Node 22.
- Copies the shared `scripts/check-node.mjs` file into the Docker builder at the path expected by the Freedom Node `prebuild` script.

## Root cause

PR #28 added a Node 22 minimum-version prebuild check, but the deployment Dockerfiles still used Node 20 and did not copy the shared check script into `/app/scripts`. The image therefore failed with `MODULE_NOT_FOUND` before reaching compilation.

## Validation

The exact unified Docker builder completed locally using Node.js 22.23.1, including the previously failing `npm run build` step.