### PR TITLE
Enable and brand the Ndani Kit pilot

### DIFF
--- a/.github/workflows/deploy-flyio.yml
+++ b/.github/workflows/deploy-flyio.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.22.0'
 
       - name: Disable Corepack and install Yarn from GitHub
         run: |
@@ -62,6 +62,11 @@ jobs:
           VITE_MIDNIGHT_INDEXER_URL: https://indexer.testnet-02.midnight.network/api/v1/graphql
           VITE_MIDNIGHT_INDEXER_WS: wss://indexer.testnet-02.midnight.network/api/v1/graphql/ws
           VITE_MIDNIGHT_NODE_URL: https://rpc.testnet-02.midnight.network
+          VITE_AGENT_ENABLED: 'true'
+          VITE_VIRTUAL_NDANI_ENABLED: 'true'
+          VITE_VIRTUAL_NDANI_COORDINATOR_ENABLED: 'false'
+          VITE_VIRTUAL_NDANI_PHYSICAL_BINDING_ENABLED: 'false'
+          VITE_VIRTUAL_NDANI_PIPELINE_DEMO_ENABLED: 'false'
 
       - name: Setup Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@master

--- a/apps/freedom-node/fly.toml
+++ b/apps/freedom-node/fly.toml
@@ -14,6 +14,12 @@ primary_region = 'iad'
   PORT = '3001'
   IPFS_SERVICE_URL = 'https://edgechain-ipfs.fly.dev'
   CORS_ORIGINS = 'https://edgechain-midnight-ui.fly.dev'
+  AGENT_ENABLED = 'true'
+  VIRTUAL_NDANI_ENABLED = 'true'
+  VIRTUAL_NDANI_COORDINATOR_ENABLED = 'false'
+  VIRTUAL_NDANI_PHYSICAL_BINDING_ENABLED = 'false'
+  VIRTUAL_NDANI_PHYSICAL_INGESTION_ENABLED = 'false'
+  VIRTUAL_NDANI_PIPELINE_DEMO_ENABLED = 'false'
 
 [[mounts]]
   source = 'edgechain_data'

--- a/apps/web/src/agent/PilotBrand.tsx
+++ b/apps/web/src/agent/PilotBrand.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom';
+
+export function PilotBrand({
+  compact = false,
+  inverse = false,
+}: {
+  compact?: boolean;
+  inverse?: boolean;
+}) {
+  return (
+    <div className={`flex items-center gap-3 ${inverse ? 'text-white' : 'text-black'}`}>
+      <Link
+        to="/pilot-login"
+        aria-label="Ndani Kit farmer access"
+        className={`grid place-items-center border-2 font-[orbitron] font-black ${
+          compact ? 'h-10 w-10 text-sm' : 'h-12 w-12 text-base'
+        } ${inverse ? 'border-white bg-[#0000ff]' : 'border-black bg-[#0000ff] text-white'}`}
+      >
+        EC
+      </Link>
+      <div>
+        <p className={`font-[orbitron] font-black uppercase tracking-[0.12em] ${
+          compact ? 'text-sm' : 'text-base'
+        }`}>
+          Ndani Kit
+        </p>
+        <p className={`font-bold uppercase tracking-[0.16em] ${
+          compact ? 'text-[10px]' : 'text-xs'
+        } ${inverse ? 'text-white/65' : 'text-[#0000ff]'}`}>
+          by EdgeChain
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/screens/FarmAssistant.tsx
+++ b/apps/web/src/screens/FarmAssistant.tsx
@@ -9,6 +9,7 @@ import type {
   AgentChatMessage,
   PilotSession,
 } from '../agent/types';
+import { PilotBrand } from '../agent/PilotBrand';
 
 export function FarmAssistant({
   session,
@@ -127,8 +128,9 @@ export function FarmAssistant({
       <div className="mx-auto max-w-5xl">
         <header className="mb-5 flex flex-col gap-4 border-2 border-black bg-white p-5 shadow-[6px_6px_0_#000] md:flex-row md:items-center md:justify-between">
           <div>
+            <PilotBrand compact />
             <p className="text-xs font-bold uppercase tracking-[0.2em] text-blue-700">
-              Virtual Ndani Kit Farm Assistant
+              <span className="mt-4 block">Virtual Ndani Kit Farm Assistant</span>
             </p>
             <h1 className="mt-1 text-3xl font-black">{session.farmer.display_name}</h1>
             <p className="text-sm text-gray-600">

--- a/apps/web/src/screens/Login.tsx
+++ b/apps/web/src/screens/Login.tsx
@@ -85,9 +85,10 @@ export function Login({
             {PILOT_AGENT_ENABLED && (
               <button
                 onClick={() => navigate('/pilot-login')}
-                className="mb-3 block w-[280px] border-2 border-black bg-white px-6 py-4 text-base font-semibold text-black hover:bg-black hover:text-white"
+                className="mb-3 block w-[280px] border-2 border-black bg-[#f1d34f] px-6 py-4 text-base font-black text-black hover:bg-black hover:text-white"
               >
-                Farmer AI Access
+                Farmer / Ndani Kit Access
+                <span className="mt-1 block text-xs font-semibold">No wallet required</span>
               </button>
             )}
             <button

--- a/apps/web/src/screens/PhysicalNdaniDemo.tsx
+++ b/apps/web/src/screens/PhysicalNdaniDemo.tsx
@@ -9,6 +9,7 @@ import type {
   PhysicalNdaniDemoSession,
   PilotSession,
 } from '../agent/types';
+import { PilotBrand } from '../agent/PilotBrand';
 
 export function PhysicalNdaniDemo({ session }: { session: PilotSession }) {
   const navigate = useNavigate();
@@ -71,8 +72,9 @@ export function PhysicalNdaniDemo({ session }: { session: PilotSession }) {
         <header className="border-4 border-[#f1d34f] bg-black p-5 sm:p-7">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
+              <PilotBrand compact inverse />
               <p className="inline-block bg-[#f1d34f] px-3 py-2 text-sm font-black uppercase tracking-[0.18em] text-black">
-                Demonstration data
+                <span className="mt-5 block">Demonstration data</span>
               </p>
               <h1 className="mt-4 text-4xl font-black leading-none sm:text-6xl">
                 See how the physical Ndani Kit works

--- a/apps/web/src/screens/PilotLogin.tsx
+++ b/apps/web/src/screens/PilotLogin.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react';
 import { AgentApiError } from '../agent/api';
+import { PilotBrand } from '../agent/PilotBrand';
 
 export function PilotLogin({
   onSubmit,
@@ -30,8 +31,9 @@ export function PilotLogin({
     <main className="min-h-screen bg-[#f7f7f2] px-5 py-10 flex items-center">
       <div className="mx-auto grid w-full max-w-5xl gap-8 lg:grid-cols-[1.1fr_0.9fr]">
         <section className="flex flex-col justify-center">
+          <PilotBrand />
           <p className="mb-4 text-sm font-bold uppercase tracking-[0.22em] text-blue-700">
-            EdgeChain Odzi Pilot
+            <span className="mt-8 block">EdgeChain Odzi Pilot</span>
           </p>
           <h1 className="max-w-2xl text-5xl font-black leading-[0.98] text-black md:text-7xl">
             Meet your farm’s Virtual Ndani Kit.

--- a/apps/web/src/screens/VirtualNdani.tsx
+++ b/apps/web/src/screens/VirtualNdani.tsx
@@ -13,6 +13,7 @@ import type {
   VirtualNdaniEvent,
   PhysicalManualComparison,
 } from '../agent/types';
+import { PilotBrand } from '../agent/PilotBrand';
 
 export function VirtualNdani({
   session,
@@ -79,8 +80,9 @@ export function VirtualNdani({
       <div className="mx-auto max-w-6xl">
         <header className="grid gap-6 border-b-2 border-black pb-7 md:grid-cols-[1fr_auto] md:items-end">
           <div>
+            <PilotBrand compact />
             <p className="text-sm font-black uppercase tracking-[0.2em] text-[#27653a]">
-              My Virtual Ndani Kit
+              <span className="mt-6 block">My Virtual Ndani Kit</span>
             </p>
             <h1 className="mt-2 text-4xl font-black leading-none sm:text-6xl">
               {device.device_code}

--- a/apps/web/src/screens/VirtualNdaniReading.tsx
+++ b/apps/web/src/screens/VirtualNdaniReading.tsx
@@ -12,6 +12,7 @@ import type {
   VirtualNdaniDevice,
   VirtualNdaniReading,
 } from '../agent/types';
+import { PilotBrand } from '../agent/PilotBrand';
 
 type FieldKey = keyof Omit<GuidedReadingDraft, 'notes'>;
 
@@ -159,10 +160,11 @@ export function VirtualNdaniReadingScreen() {
   return (
     <ReadingShell>
       <header className="border-b-2 border-black pb-5">
+        <PilotBrand compact />
         <button
           type="button"
           onClick={() => navigate('/virtual-ndani')}
-          className="text-sm font-black uppercase tracking-wide underline"
+          className="mt-6 text-sm font-black uppercase tracking-wide underline"
         >
           Back to Virtual Ndani Kit
         </button>
@@ -350,7 +352,7 @@ function Confirmation({
 
 function ReadingShell({ children }: { children: React.ReactNode }) {
   return (
-    <main className="min-h-screen bg-[#f4f1e8] px-4 py-10 text-[#171713] sm:px-6">
+    <main className="min-h-screen border-t-4 border-[#0000ff] bg-[#f4f1e8] px-4 py-10 text-[#171713] sm:px-6">
       <div className="mx-auto max-w-3xl">{children}</div>
     </main>
   );


### PR DESCRIPTION
## What changed

- Adds a prominent **Farmer / Ndani Kit Access** entry point to the main EdgeChain landing page with clear **No wallet required** guidance.
- Adds a reusable **Ndani Kit by EdgeChain** identity across farmer login, Virtual Ndani Kit, guided readings, Farm Assistant, and physical demonstration screens.
- Preserves the farmer-friendly cream/green/yellow interface while introducing EdgeChain blue accents and Orbitron branding.
- Enables the core AI Farm Agent and Virtual Ndani Kit in the production frontend and backend configuration.
- Keeps coordinator access, physical binding/ingestion, and demonstration pipelines explicitly disabled for the initial production rollout.
- Updates the Fly deployment workflow to use Node.js 22.22.0.

## Why

The pilot code was deployed but invisible because its production feature flags were not set. This change makes farmer access discoverable without forcing wallet authentication and visually connects the simplified pilot experience to the main EdgeChain product.

## Validation

- Production-flagged web build passed on Node.js 22.22.0.
- Freedom Node build passed.
- Web inference tests passed.
- New pilot branding and farmer screens pass targeted ESLint.
- Main landing page renders the farmer access button and no-wallet guidance.
- Pilot login and farmer screens render the Ndani Kit by EdgeChain identity.
- `git diff --check` passed.

## Deployment order

Merge PR #29 first. It updates the deployment Dockerfiles to Node 22 and copies the shared Node runtime check into the Docker builder. Without that fix, the Fly deployment will fail before this production configuration can be released.