### PR TITLE
Fix production farmer session cookies

### DIFF
--- a/apps/freedom-node/src/auth/session.ts
+++ b/apps/freedom-node/src/auth/session.ts
@@ -24,30 +24,42 @@ export function readSessionToken(req: Request): string | undefined {
   return cookies[FARMER_SESSION_COOKIE];
 }
 
-export function setSessionCookie(res: Response, token: string): void {
+export function setSessionCookie(res: Response, token: string, req?: Request): void {
   const secure = process.env.NODE_ENV === 'production';
   const attributes = [
     `${FARMER_SESSION_COOKIE}=${encodeURIComponent(token)}`,
     'Path=/',
     'HttpOnly',
-    `SameSite=${secure ? 'None' : 'Lax'}`,
+    `SameSite=${cookieSameSite(secure, req)}`,
     `Max-Age=${sessionLifetimeSeconds()}`,
   ];
   if (secure) attributes.push('Secure');
   res.setHeader('Set-Cookie', attributes.join('; '));
 }
 
-export function clearSessionCookie(res: Response): void {
+export function clearSessionCookie(res: Response, req?: Request): void {
   const secure = process.env.NODE_ENV === 'production';
   const attributes = [
     `${FARMER_SESSION_COOKIE}=`,
     'Path=/',
     'HttpOnly',
-    `SameSite=${secure ? 'None' : 'Lax'}`,
+    `SameSite=${cookieSameSite(secure, req)}`,
     'Max-Age=0',
   ];
   if (secure) attributes.push('Secure');
   res.setHeader('Set-Cookie', attributes.join('; '));
+}
+
+function cookieSameSite(secure: boolean, req?: Request): 'Lax' | 'None' {
+  if (!secure || !req) return 'Lax';
+  const origin = req.header('origin');
+  const host = req.header('host');
+  if (!origin || !host) return 'Lax';
+  try {
+    return new URL(origin).host === host ? 'Lax' : 'None';
+  } catch {
+    return 'Lax';
+  }
 }
 
 function parseCookieHeader(header?: string): Record<string, string> {

--- a/apps/freedom-node/src/routes/auth.ts
+++ b/apps/freedom-node/src/routes/auth.ts
@@ -65,7 +65,7 @@ router.post('/enroll-coordinator', async (req, res) => {
 router.post('/login', async (req, res) => {
   try {
     const result = await authService.login(req.body.pilot_code, String(req.body.pin ?? ''));
-    setSessionCookie(res, result.sessionToken);
+    setSessionCookie(res, result.sessionToken, req);
     return res.json({
       success: true,
       farmer: publicFarmer(result.farmer),
@@ -83,7 +83,7 @@ router.post('/logout', requireFarmerSession, async (req: FarmerRequest, res) => 
   if (req.sessionTokenHash) {
     await authRepository.revokeSession(req.sessionTokenHash);
   }
-  clearSessionCookie(res);
+  clearSessionCookie(res, req);
   return res.json({ success: true });
 });
 


### PR DESCRIPTION
## What changed

- Uses `SameSite=Lax` for the unified same-origin EdgeChain deployment.
- Retains `SameSite=None; Secure` when the frontend and backend run on separate origins.
- Applies the same policy when clearing the session cookie.
- Passes the request context into login/logout cookie handling so the policy can be selected safely.

## Root cause

The production administrator credentials were valid and the login API returned HTTP 200, but the deployed browser did not retain/return the `SameSite=None` session cookie in the unified same-origin deployment. The subsequent session request therefore failed and the UI displayed “EdgeChain could not sign you in.”

## Validation

- Reproduced the failure through the deployed browser UI.
- Confirmed the production account and migrations are valid through direct login/session API calls.
- Verified same-origin cookies render as `SameSite=Lax; Secure`.
- Verified cross-origin cookies remain `SameSite=None; Secure`.
- Freedom Node build passed.
- Freedom Node foundation tests passed against PostgreSQL.
- `git diff --check` passed.