### PR TITLE
Add coordinator farmer deletion and role-based pilot routing

### DIFF
--- a/apps/freedom-node/src/routes/coordinator.ts
+++ b/apps/freedom-node/src/routes/coordinator.ts
@@ -73,6 +73,18 @@ router.post('/farmers/:farmerId/reset-pin', async (req: FarmerRequest, res) => {
   }
 });
 
+router.delete('/farmers/:farmerId', async (req: FarmerRequest, res) => {
+  try {
+    const result = await coordinatorAdministrationService.deleteFarmer({
+      farmerId: req.params.farmerId,
+      coordinatorId: req.farmer!.farmer_id,
+    });
+    return res.json({ success: true, result });
+  } catch (error) {
+    return handleError(error, res);
+  }
+});
+
 router.get('/virtual-ndani', async (_req: FarmerRequest, res) => {
   try {
     return res.json({ success: true, devices: await coordinatorService.fleet() });

--- a/apps/freedom-node/src/test-coordinator-integration.ts
+++ b/apps/freedom-node/src/test-coordinator-integration.ts
@@ -109,6 +109,36 @@ async function run(): Promise<void> {
       /invalid_credentials/
     );
 
+    await coordinatorAdministrationService.deleteFarmer({
+      farmerId: administered.farmer_id,
+      coordinatorId: coordinator.farmer_id,
+    });
+    await assert.rejects(
+      authService.login(`ADMIN-${suffix}`, '2468'),
+      /invalid_credentials/
+    );
+    const deletedAdministeredFarmer = await db.query(
+      'SELECT COUNT(*)::int AS count FROM farmers WHERE farmer_id = $1',
+      [administered.farmer_id]
+    );
+    assert.equal(Number(deletedAdministeredFarmer.rows[0].count), 0);
+    const deletedAdministeredFarm = await db.query(
+      'SELECT COUNT(*)::int AS count FROM farms WHERE farm_id = $1',
+      [administered.farm_id]
+    );
+    assert.equal(Number(deletedAdministeredFarm.rows[0].count), 0);
+    const deletedAdministeredDevice = await db.query(
+      'SELECT COUNT(*)::int AS count FROM virtual_ndani_devices WHERE virtual_device_id = $1',
+      [administered.virtual_device_id]
+    );
+    assert.equal(Number(deletedAdministeredDevice.rows[0].count), 0);
+    await assert.rejects(
+      coordinatorAdministrationService.findFarmer(administered.farmer_id),
+      /farmer_not_found/
+    );
+    administeredFarmerId = undefined;
+    administeredFarmId = undefined;
+
     const devices = await virtualNdaniService.list(farmer.farmer_id);
     const device = devices[0];
     farmId = device.farm_id;

--- a/apps/freedom-node/src/virtual-ndani/coordinatorAdministrationService.ts
+++ b/apps/freedom-node/src/virtual-ndani/coordinatorAdministrationService.ts
@@ -216,6 +216,42 @@ export const coordinatorAdministrationService = {
     return { farmer_id: input.farmerId, sessions_revoked: true };
   },
 
+  async deleteFarmer(input: {
+    farmerId: string;
+    coordinatorId: string;
+  }) {
+    const current = await this.findFarmer(input.farmerId);
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+      await insertAudit(client, input.coordinatorId, 'farmer_deleted', input.farmerId, {
+        pilot_code: current.pilot_code,
+        farm_id: current.farm_id,
+        site_id: current.site_id,
+        virtual_device_id: current.virtual_device_id,
+        device_code: current.device_code,
+      });
+      if (current.farm_id) {
+        await client.query('DELETE FROM farms WHERE farm_id = $1', [current.farm_id]);
+      }
+      await client.query(
+        'DELETE FROM farmers WHERE farmer_id = $1 AND system_role = $2',
+        [input.farmerId, 'farmer']
+      );
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+    return {
+      farmer_id: input.farmerId,
+      farm_id: current.farm_id,
+      deleted: true,
+    };
+  },
+
   async findFarmer(farmerId: string) {
     if (!isUuid(farmerId)) {
       throw new CoordinatorAdministrationError('farmer_not_found', 404);

--- a/apps/web/src/agent/api.ts
+++ b/apps/web/src/agent/api.ts
@@ -283,6 +283,14 @@ export async function resetCoordinatorFarmerPin(
   if (!response.ok) throw await toApiError(response);
 }
 
+export async function deleteCoordinatorFarmer(farmerId: string): Promise<void> {
+  const response = await request(
+    `/api/v1/coordinator/farmers/${encodeURIComponent(farmerId)}`,
+    { method: 'DELETE' }
+  );
+  if (!response.ok) throw await toApiError(response);
+}
+
 export async function loadCoordinatorReviews(): Promise<CoordinatorReadingReview[]> {
   const response = await request('/api/v1/coordinator/reading-reviews', {
     method: 'GET',

--- a/apps/web/src/agent/pilotNavigation.ts
+++ b/apps/web/src/agent/pilotNavigation.ts
@@ -1,0 +1,28 @@
+import {
+  VIRTUAL_NDANI_COORDINATOR_ENABLED,
+  VIRTUAL_NDANI_ENABLED,
+} from './api';
+import type { PilotSession } from './types';
+
+const FARMER_RETURN_PATHS = new Set([
+  '/virtual-ndani',
+  '/virtual-ndani/reading',
+  '/virtual-ndani/demo',
+  '/farm-assistant',
+]);
+
+export function pilotDestination(
+  session: PilotSession,
+  requestedPath?: unknown
+): string {
+  if (session.farmer.system_role === 'coordinator') {
+    return VIRTUAL_NDANI_COORDINATOR_ENABLED ? '/coordinator' : '/';
+  }
+  if (
+    typeof requestedPath === 'string'
+    && FARMER_RETURN_PATHS.has(requestedPath)
+  ) {
+    return requestedPath;
+  }
+  return VIRTUAL_NDANI_ENABLED ? '/virtual-ndani' : '/farm-assistant';
+}

--- a/apps/web/src/routes/FarmAssistantRoute.tsx
+++ b/apps/web/src/routes/FarmAssistantRoute.tsx
@@ -22,6 +22,9 @@ export function FarmAssistantRoute() {
       />
     );
   }
+  if (agent.session.farmer.system_role === 'coordinator') {
+    return <Navigate to="/coordinator" replace />;
+  }
 
   return (
     <FarmAssistant

--- a/apps/web/src/routes/PilotLoginRoute.tsx
+++ b/apps/web/src/routes/PilotLoginRoute.tsx
@@ -1,10 +1,7 @@
 import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { useAgentSession } from '../agent/agentSessionContext';
 import { PilotLogin } from '../screens/PilotLogin';
-import {
-  VIRTUAL_NDANI_COORDINATOR_ENABLED,
-  VIRTUAL_NDANI_ENABLED,
-} from '../agent/api';
+import { pilotDestination } from '../agent/pilotNavigation';
 
 export function PilotLoginRoute() {
   const agent = useAgentSession();
@@ -18,26 +15,19 @@ export function PilotLoginRoute() {
     return <PilotLoading label="Checking your EdgeChain access…" />;
   }
   if (agent.session) {
-    const destination = typeof location.state?.from === 'string'
-      ? location.state.from
-      : agent.session.farmer.system_role === 'coordinator'
-        && VIRTUAL_NDANI_COORDINATOR_ENABLED
-        ? '/coordinator'
-        : VIRTUAL_NDANI_ENABLED ? '/virtual-ndani' : '/farm-assistant';
-    return <Navigate to={destination} replace />;
+    return (
+      <Navigate
+        to={pilotDestination(agent.session, location.state?.from)}
+        replace
+      />
+    );
   }
 
   return (
     <PilotLogin
       onSubmit={async (pilotCode, pin) => {
         const session = await agent.login(pilotCode, pin);
-        navigate(
-          session?.farmer.system_role === 'coordinator'
-            && VIRTUAL_NDANI_COORDINATOR_ENABLED
-            ? '/coordinator'
-            : VIRTUAL_NDANI_ENABLED ? '/virtual-ndani' : '/farm-assistant',
-          { replace: true }
-        );
+        if (session) navigate(pilotDestination(session), { replace: true });
       }}
       onWalletAccess={() => navigate('/')}
     />

--- a/apps/web/src/routes/VirtualNdaniReadingRoute.tsx
+++ b/apps/web/src/routes/VirtualNdaniReadingRoute.tsx
@@ -13,5 +13,8 @@ export function VirtualNdaniReadingRoute() {
   if (!agent.session) {
     return <Navigate to="/pilot-login" state={{ from: location.pathname }} replace />;
   }
+  if (agent.session.farmer.system_role === 'coordinator') {
+    return <Navigate to="/coordinator" replace />;
+  }
   return <VirtualNdaniReadingScreen />;
 }

--- a/apps/web/src/routes/VirtualNdaniRoute.tsx
+++ b/apps/web/src/routes/VirtualNdaniRoute.tsx
@@ -23,6 +23,9 @@ export function VirtualNdaniRoute() {
       />
     );
   }
+  if (agent.session.farmer.system_role === 'coordinator') {
+    return <Navigate to="/coordinator" replace />;
+  }
 
   return <VirtualNdani session={agent.session} onLogout={agent.logout} />;
 }

--- a/apps/web/src/screens/FarmerAdministration.tsx
+++ b/apps/web/src/screens/FarmerAdministration.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react';
 import {
+  deleteCoordinatorFarmer,
   enrollCoordinatorFarmer,
   resetCoordinatorFarmerPin,
   updateCoordinatorFarmer,
@@ -104,6 +105,20 @@ export function FarmerAdministration({
                 setWorkingId(null);
               }
             }}
+            onDelete={async () => {
+              setWorkingId(farmer.farmer_id);
+              setError(null);
+              setMessage(null);
+              try {
+                await deleteCoordinatorFarmer(farmer.farmer_id);
+                setMessage(`${farmer.pilot_code} and their Ndani Kit were deleted.`);
+                await onChanged();
+              } catch (deleteError) {
+                setError(errorMessage(deleteError));
+              } finally {
+                setWorkingId(null);
+              }
+            }}
           />
         ))}
       </div>
@@ -204,6 +219,7 @@ function FarmerCard({
   working,
   onSave,
   onResetPin,
+  onDelete,
 }: {
   farmer: CoordinatorFarmer;
   working: boolean;
@@ -214,6 +230,7 @@ function FarmerCard({
     farmDisplayName: string;
   }) => Promise<void>;
   onResetPin: (pin: string) => Promise<void>;
+  onDelete: () => Promise<void>;
 }) {
   const [editing, setEditing] = useState(false);
   const [displayName, setDisplayName] = useState(farmer.display_name);
@@ -304,6 +321,26 @@ function FarmerCard({
               </button>
             </div>
             <p className="mt-2 text-xs text-gray-600">Resetting the PIN signs the farmer out on all devices.</p>
+          </div>
+
+          <div className="mt-5 border-t border-red-200 pt-4">
+            <p className="text-sm font-black text-red-800">Delete farmer</p>
+            <p className="mt-1 text-xs text-gray-600">
+              This removes the farmer profile, farm assignment, sessions and Virtual Ndani Kit records.
+            </p>
+            <button
+              type="button"
+              disabled={working}
+              onClick={() => {
+                const confirmed = window.confirm(
+                  `Delete ${farmer.pilot_code} and their Ndani Kit? This cannot be undone.`
+                );
+                if (confirmed) void onDelete();
+              }}
+              className="mt-3 border-2 border-red-800 bg-red-50 px-4 py-2 font-black text-red-800 disabled:opacity-40"
+            >
+              Delete farmer
+            </button>
           </div>
         </div>
       )}


### PR DESCRIPTION
Adds coordinator admin support for deleting farmer profiles and their assigned Ndani Kit records.

Also fixes coordinator login routing so admin users are always sent to /coordinator instead of stale farmer-only return paths.

Validation:
- Web ESLint passed
- Freedom node build passed with Node 22
- Web build passed with Node 22
- diff check passed