### PR TITLE
Add AI profile onboarding and site modes

### DIFF
--- a/.github/workflows/deploy-flyio.yml
+++ b/.github/workflows/deploy-flyio.yml
@@ -62,12 +62,16 @@ jobs:
           VITE_MIDNIGHT_INDEXER_URL: https://indexer.testnet-02.midnight.network/api/v1/graphql
           VITE_MIDNIGHT_INDEXER_WS: wss://indexer.testnet-02.midnight.network/api/v1/graphql/ws
           VITE_MIDNIGHT_NODE_URL: https://rpc.testnet-02.midnight.network
-          VITE_API_URL: https://edgechain-midnight.fly.dev
+          # Empty means same-origin API calls. This lets the same Fly app serve
+          # both funder and farmer custom domains without cross-domain cookies.
+          VITE_API_URL: ''
           VITE_AGENT_ENABLED: 'true'
           VITE_VIRTUAL_NDANI_ENABLED: 'true'
           VITE_VIRTUAL_NDANI_COORDINATOR_ENABLED: 'true'
           VITE_VIRTUAL_NDANI_PHYSICAL_BINDING_ENABLED: 'false'
           VITE_VIRTUAL_NDANI_PIPELINE_DEMO_ENABLED: 'false'
+          VITE_FUNDER_SITE_HOSTS: ${{ vars.VITE_FUNDER_SITE_HOSTS }}
+          VITE_FARMER_SITE_HOSTS: ${{ vars.VITE_FARMER_SITE_HOSTS }}
 
       - name: Setup Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@master

--- a/apps/freedom-node/src/ai-farm-manager/coordinatorProfileService.ts
+++ b/apps/freedom-node/src/ai-farm-manager/coordinatorProfileService.ts
@@ -1,0 +1,160 @@
+import { coordinatorAdministrationService } from '../virtual-ndani/coordinatorAdministrationService';
+import { aiFarmManagerRepository } from './repository';
+import { FarmerAiProfile, FarmManagerLanguage } from './domain';
+
+const LANGUAGES = ['en', 'sn', 'sn-en'] as const;
+const PROFILE_STATUSES = ['draft', 'active', 'needs_update', 'archived'] as const;
+
+export class AiFarmManagerProfileError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number
+  ) {
+    super(code);
+  }
+}
+
+export const coordinatorAiProfileService = {
+  async getProfile(farmerId: string): Promise<FarmerAiProfile | null> {
+    const farmer = await coordinatorAdministrationService.findFarmer(farmerId);
+    const profile = await aiFarmManagerRepository.getActiveProfile({
+      farmerId,
+      farmId: farmer.farm_id ?? undefined,
+    });
+    return profile ?? null;
+  },
+
+  async saveProfile(input: {
+    farmerId: string;
+    preferredLanguage: unknown;
+    literacyLevel: unknown;
+    technologyComfort: unknown;
+    primaryGoal: unknown;
+    primaryPainPoint: unknown;
+    secondaryPainPoints: unknown;
+    waterAccess: unknown;
+    irrigationMethod: unknown;
+    budgetConstraint: unknown;
+    labourConstraint: unknown;
+    mainCrops: unknown;
+    currentCrop: unknown;
+    currentCropStage: unknown;
+    soilType: unknown;
+    farmStorySummary: unknown;
+    aiManagerBrief: unknown;
+    status: unknown;
+  }): Promise<FarmerAiProfile> {
+    const farmer = await coordinatorAdministrationService.findFarmer(input.farmerId);
+    const preferredLanguage = enumValue(
+      input.preferredLanguage,
+      LANGUAGES,
+      'invalid_language',
+      farmer.preferred_language
+    );
+    const status = enumValue(input.status, PROFILE_STATUSES, 'invalid_profile_status', 'active');
+    const profileInput = {
+      preferredLanguage,
+      literacyLevel: optionalText(input.literacyLevel, 80),
+      technologyComfort: optionalText(input.technologyComfort, 80),
+      primaryGoal: optionalText(input.primaryGoal, 120),
+      primaryPainPoint: optionalText(input.primaryPainPoint, 120),
+      secondaryPainPoints: stringList(input.secondaryPainPoints, 8, 80),
+      waterAccess: optionalText(input.waterAccess, 120),
+      irrigationMethod: optionalText(input.irrigationMethod, 120),
+      budgetConstraint: optionalText(input.budgetConstraint, 160),
+      labourConstraint: optionalText(input.labourConstraint, 160),
+      mainCrops: stringList(input.mainCrops, 12, 60),
+      currentCrop: optionalText(input.currentCrop, 80),
+      currentCropStage: optionalText(input.currentCropStage, 80),
+      soilType: optionalText(input.soilType, 80),
+      farmStorySummary: optionalText(input.farmStorySummary, 1200),
+      status,
+    };
+    const brief = optionalText(input.aiManagerBrief, 1200)
+      || generateBrief({
+        farmerName: farmer.display_name,
+        farmName: farmer.farm_display_name || 'Farm',
+        primaryPainPoint: profileInput.primaryPainPoint,
+        currentCrop: profileInput.currentCrop,
+        currentCropStage: profileInput.currentCropStage,
+        waterAccess: profileInput.waterAccess,
+        mainCrops: profileInput.mainCrops,
+      });
+
+    const existing = await aiFarmManagerRepository.getActiveProfile({
+      farmerId: input.farmerId,
+      farmId: farmer.farm_id ?? undefined,
+    });
+
+    if (existing) {
+      const updated = await aiFarmManagerRepository.updateProfile({
+        profileId: existing.profile_id,
+        ...profileInput,
+        aiManagerBrief: brief,
+      });
+      if (!updated) throw new AiFarmManagerProfileError('ai_profile_not_found', 404);
+      return updated;
+    }
+
+    return aiFarmManagerRepository.createProfile({
+      farmerId: input.farmerId,
+      farmId: farmer.farm_id,
+      ...profileInput,
+      aiManagerBrief: brief,
+    });
+  },
+};
+
+function generateBrief(input: {
+  farmerName: string;
+  farmName: string;
+  primaryPainPoint: string | null;
+  currentCrop: string | null;
+  currentCropStage: string | null;
+  waterAccess: string | null;
+  mainCrops: string[];
+}): string {
+  const crop = input.currentCrop || input.mainCrops[0] || 'the current crop';
+  const stage = input.currentCropStage ? ` at ${input.currentCropStage} stage` : '';
+  const painPoint = input.primaryPainPoint || 'weekly farm decision support';
+  const water = input.waterAccess ? ` Water context: ${input.waterAccess}.` : '';
+  return `${input.farmerName}'s AI Farm Manager for ${input.farmName} should focus on ${painPoint}, with special attention to ${crop}${stage}.${water}`;
+}
+
+function optionalText(value: unknown, maximum: number): string | null {
+  const normalized = String(value ?? '').trim();
+  if (!normalized) return null;
+  if (normalized.length > maximum) {
+    throw new AiFarmManagerProfileError('profile_field_too_long', 400);
+  }
+  return normalized;
+}
+
+function stringList(value: unknown, maximumItems: number, maximumLength: number): string[] {
+  const rawItems = Array.isArray(value)
+    ? value
+    : String(value ?? '')
+      .split(',')
+      .map((item) => item.trim());
+  const items = rawItems
+    .map((item) => String(item ?? '').trim())
+    .filter(Boolean)
+    .slice(0, maximumItems);
+  if (items.some((item) => item.length > maximumLength)) {
+    throw new AiFarmManagerProfileError('profile_list_item_too_long', 400);
+  }
+  return [...new Set(items)];
+}
+
+function enumValue<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  errorCode: string,
+  fallback: T
+): T {
+  const normalized = String(value ?? fallback).trim().toLowerCase() as T;
+  if (!allowed.includes(normalized)) {
+    throw new AiFarmManagerProfileError(errorCode, 400);
+  }
+  return normalized;
+}

--- a/apps/freedom-node/src/routes/coordinator.ts
+++ b/apps/freedom-node/src/routes/coordinator.ts
@@ -12,6 +12,10 @@ import {
   CoordinatorAdministrationError,
   coordinatorAdministrationService,
 } from '../virtual-ndani/coordinatorAdministrationService';
+import {
+  AiFarmManagerProfileError,
+  coordinatorAiProfileService,
+} from '../ai-farm-manager/coordinatorProfileService';
 
 const router = Router();
 router.use(requireCoordinator);
@@ -55,6 +59,45 @@ router.patch('/farmers/:farmerId', async (req: FarmerRequest, res) => {
       coordinatorId: req.farmer!.farmer_id,
     });
     return res.json({ success: true, farmer });
+  } catch (error) {
+    return handleError(error, res);
+  }
+});
+
+router.get('/farmers/:farmerId/ai-profile', async (req: FarmerRequest, res) => {
+  try {
+    return res.json({
+      success: true,
+      profile: await coordinatorAiProfileService.getProfile(req.params.farmerId),
+    });
+  } catch (error) {
+    return handleError(error, res);
+  }
+});
+
+router.patch('/farmers/:farmerId/ai-profile', async (req: FarmerRequest, res) => {
+  try {
+    const profile = await coordinatorAiProfileService.saveProfile({
+      farmerId: req.params.farmerId,
+      preferredLanguage: req.body.preferred_language,
+      literacyLevel: req.body.literacy_level,
+      technologyComfort: req.body.technology_comfort,
+      primaryGoal: req.body.primary_goal,
+      primaryPainPoint: req.body.primary_pain_point,
+      secondaryPainPoints: req.body.secondary_pain_points,
+      waterAccess: req.body.water_access,
+      irrigationMethod: req.body.irrigation_method,
+      budgetConstraint: req.body.budget_constraint,
+      labourConstraint: req.body.labour_constraint,
+      mainCrops: req.body.main_crops,
+      currentCrop: req.body.current_crop,
+      currentCropStage: req.body.current_crop_stage,
+      soilType: req.body.soil_type,
+      farmStorySummary: req.body.farm_story_summary,
+      aiManagerBrief: req.body.ai_manager_brief,
+      status: req.body.status,
+    });
+    return res.json({ success: true, profile });
   } catch (error) {
     return handleError(error, res);
   }
@@ -230,6 +273,9 @@ function handleError(error: unknown, res: any) {
     return res.status(error.status).json({ error: error.code });
   }
   if (error instanceof CoordinatorAdministrationError) {
+    return res.status(error.status).json({ error: error.code });
+  }
+  if (error instanceof AiFarmManagerProfileError) {
     return res.status(error.status).json({ error: error.code });
   }
   console.error('Coordinator request failed:', error);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,7 @@ import { VirtualNdaniReadingRoute } from "./routes/VirtualNdaniReadingRoute";
 import { CoordinatorRoute } from "./routes/CoordinatorRoute";
 import { PhysicalNdaniDemoRoute } from "./routes/PhysicalNdaniDemoRoute";
 import { AgentSessionProvider } from "./agent/AgentSessionProvider";
+import { isFarmerSite } from "./agent/siteMode";
 import Navbar from "./components/Navbar";
 import "./app.css";
 import { Toaster } from "sonner";
@@ -29,7 +30,7 @@ export default function EdgeChainApp() {
           <Toaster position="top-right" />
           <Routes>
             {/* Existing wallet-first application routes */}
-            <Route path="/" element={<LoginRoute />} />
+            <Route path="/" element={<HomeRoute />} />
             <Route path="/register" element={<RegisterRoute />} />
             <Route path="/selection" element={<SelectionRoute />} />
             <Route path="/sensor-node" element={<IoTRoute />} />
@@ -51,4 +52,8 @@ export default function EdgeChainApp() {
       </AgentSessionProvider>
     </AppProvider>
   );
+}
+
+function HomeRoute() {
+  return isFarmerSite() ? <Navigate to="/pilot-login" replace /> : <LoginRoute />;
 }

--- a/apps/web/src/agent/api.ts
+++ b/apps/web/src/agent/api.ts
@@ -11,6 +11,7 @@ import type {
   CoordinatorFleetDevice,
   CoordinatorFarmer,
   CoordinatorReadingReview,
+  FarmerAiProfile,
   PilotOperationsMetrics,
   PilotEvidenceReport,
   PhysicalBindingChallenge,
@@ -289,6 +290,74 @@ export async function deleteCoordinatorFarmer(farmerId: string): Promise<void> {
     { method: 'DELETE' }
   );
   if (!response.ok) throw await toApiError(response);
+}
+
+export async function loadCoordinatorFarmerAiProfile(
+  farmerId: string
+): Promise<FarmerAiProfile | null> {
+  const response = await request(
+    `/api/v1/coordinator/farmers/${encodeURIComponent(farmerId)}/ai-profile`,
+    { method: 'GET' }
+  );
+  if (!response.ok) throw await toApiError(response);
+  const body = await response.json() as {
+    success: true;
+    profile: FarmerAiProfile | null;
+  };
+  return body.profile;
+}
+
+export async function saveCoordinatorFarmerAiProfile(input: {
+  farmerId: string;
+  preferredLanguage: 'en' | 'sn' | 'sn-en';
+  literacyLevel: string;
+  technologyComfort: string;
+  primaryGoal: string;
+  primaryPainPoint: string;
+  secondaryPainPoints: string[];
+  waterAccess: string;
+  irrigationMethod: string;
+  budgetConstraint: string;
+  labourConstraint: string;
+  mainCrops: string[];
+  currentCrop: string;
+  currentCropStage: string;
+  soilType: string;
+  farmStorySummary: string;
+  aiManagerBrief: string;
+  status: 'draft' | 'active' | 'needs_update' | 'archived';
+}): Promise<FarmerAiProfile> {
+  const response = await request(
+    `/api/v1/coordinator/farmers/${encodeURIComponent(input.farmerId)}/ai-profile`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({
+        preferred_language: input.preferredLanguage,
+        literacy_level: input.literacyLevel,
+        technology_comfort: input.technologyComfort,
+        primary_goal: input.primaryGoal,
+        primary_pain_point: input.primaryPainPoint,
+        secondary_pain_points: input.secondaryPainPoints,
+        water_access: input.waterAccess,
+        irrigation_method: input.irrigationMethod,
+        budget_constraint: input.budgetConstraint,
+        labour_constraint: input.labourConstraint,
+        main_crops: input.mainCrops,
+        current_crop: input.currentCrop,
+        current_crop_stage: input.currentCropStage,
+        soil_type: input.soilType,
+        farm_story_summary: input.farmStorySummary,
+        ai_manager_brief: input.aiManagerBrief,
+        status: input.status,
+      }),
+    }
+  );
+  if (!response.ok) throw await toApiError(response);
+  const body = await response.json() as {
+    success: true;
+    profile: FarmerAiProfile;
+  };
+  return body.profile;
 }
 
 export async function loadCoordinatorReviews(): Promise<CoordinatorReadingReview[]> {

--- a/apps/web/src/agent/siteMode.ts
+++ b/apps/web/src/agent/siteMode.ts
@@ -1,0 +1,34 @@
+export type EdgeChainSiteMode = 'farmer' | 'funder';
+
+const configuredFarmerHosts = hostList(import.meta.env.VITE_FARMER_SITE_HOSTS);
+const configuredFunderHosts = hostList(import.meta.env.VITE_FUNDER_SITE_HOSTS);
+
+export function siteMode(hostname = window.location.hostname): EdgeChainSiteMode {
+  const normalized = hostname.toLowerCase();
+  if (matchesHost(normalized, configuredFarmerHosts)) return 'farmer';
+  if (matchesHost(normalized, configuredFunderHosts)) return 'funder';
+  if (
+    normalized.startsWith('farmer.')
+    || normalized.startsWith('farmers.')
+    || normalized.startsWith('odzi.')
+    || normalized.startsWith('pilot.')
+  ) {
+    return 'farmer';
+  }
+  return 'funder';
+}
+
+export function isFarmerSite(hostname?: string): boolean {
+  return siteMode(hostname) === 'farmer';
+}
+
+function hostList(value: unknown): string[] {
+  return String(value || '')
+    .split(',')
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function matchesHost(hostname: string, hosts: string[]): boolean {
+  return hosts.some((host) => hostname === host || hostname.endsWith(`.${host}`));
+}

--- a/apps/web/src/agent/types.ts
+++ b/apps/web/src/agent/types.ts
@@ -69,6 +69,32 @@ export interface CoordinatorFarmer {
   gemini_request_count: number;
 }
 
+export interface FarmerAiProfile {
+  profile_id: string;
+  farmer_id: string;
+  farm_id: string | null;
+  preferred_language: 'en' | 'sn' | 'sn-en';
+  literacy_level: string | null;
+  technology_comfort: string | null;
+  primary_goal: string | null;
+  primary_pain_point: string | null;
+  secondary_pain_points: string[];
+  water_access: string | null;
+  irrigation_method: string | null;
+  budget_constraint: string | null;
+  labour_constraint: string | null;
+  main_crops: string[];
+  current_crop: string | null;
+  current_crop_stage: string | null;
+  soil_type: string | null;
+  farm_story_summary: string | null;
+  ai_manager_brief: string | null;
+  brief_version: number;
+  status: 'draft' | 'active' | 'needs_update' | 'archived';
+  created_at: number;
+  updated_at: number;
+}
+
 export interface PilotOperationsMetrics {
   devices: number;
   total_cycles: number;

--- a/apps/web/src/screens/FarmerAdministration.tsx
+++ b/apps/web/src/screens/FarmerAdministration.tsx
@@ -1,11 +1,13 @@
-import { useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import {
   deleteCoordinatorFarmer,
   enrollCoordinatorFarmer,
+  loadCoordinatorFarmerAiProfile,
   resetCoordinatorFarmerPin,
+  saveCoordinatorFarmerAiProfile,
   updateCoordinatorFarmer,
 } from '../agent/api';
-import type { CoordinatorFarmer } from '../agent/types';
+import type { CoordinatorFarmer, FarmerAiProfile } from '../agent/types';
 
 export function FarmerAdministration({
   farmers,
@@ -300,6 +302,8 @@ function FarmerCard({
             Save profile
           </button>
 
+          <AiManagerProfileEditor farmer={farmer} working={working} />
+
           <div className="mt-5 border-t border-gray-300 pt-4">
             <p className="text-sm font-black">Reset personal PIN</p>
             <div className="mt-2 flex gap-2">
@@ -348,6 +352,208 @@ function FarmerCard({
   );
 }
 
+function AiManagerProfileEditor({
+  farmer,
+  working,
+}: {
+  farmer: CoordinatorFarmer;
+  working: boolean;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [profile, setProfile] = useState<FarmerAiProfile | null>(null);
+  const [preferredLanguage, setPreferredLanguage] =
+    useState<'en' | 'sn' | 'sn-en'>(farmer.preferred_language);
+  const [literacyLevel, setLiteracyLevel] = useState('');
+  const [technologyComfort, setTechnologyComfort] = useState('');
+  const [primaryGoal, setPrimaryGoal] = useState('');
+  const [primaryPainPoint, setPrimaryPainPoint] = useState('');
+  const [secondaryPainPoints, setSecondaryPainPoints] = useState('');
+  const [waterAccess, setWaterAccess] = useState('');
+  const [irrigationMethod, setIrrigationMethod] = useState('');
+  const [budgetConstraint, setBudgetConstraint] = useState('');
+  const [labourConstraint, setLabourConstraint] = useState('');
+  const [mainCrops, setMainCrops] = useState('');
+  const [currentCrop, setCurrentCrop] = useState('');
+  const [currentCropStage, setCurrentCropStage] = useState('');
+  const [soilType, setSoilType] = useState('');
+  const [farmStorySummary, setFarmStorySummary] = useState('');
+  const [aiManagerBrief, setAiManagerBrief] = useState('');
+  const [profileStatus, setProfileStatus] =
+    useState<'draft' | 'active' | 'needs_update' | 'archived'>('active');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void loadCoordinatorFarmerAiProfile(farmer.farmer_id)
+      .then((loaded) => {
+        if (cancelled) return;
+        setProfile(loaded);
+        setPreferredLanguage(loaded?.preferred_language || farmer.preferred_language);
+        setLiteracyLevel(loaded?.literacy_level || '');
+        setTechnologyComfort(loaded?.technology_comfort || '');
+        setPrimaryGoal(loaded?.primary_goal || '');
+        setPrimaryPainPoint(loaded?.primary_pain_point || '');
+        setSecondaryPainPoints((loaded?.secondary_pain_points || []).join(', '));
+        setWaterAccess(loaded?.water_access || '');
+        setIrrigationMethod(loaded?.irrigation_method || '');
+        setBudgetConstraint(loaded?.budget_constraint || '');
+        setLabourConstraint(loaded?.labour_constraint || '');
+        setMainCrops((loaded?.main_crops || []).join(', '));
+        setCurrentCrop(loaded?.current_crop || '');
+        setCurrentCropStage(loaded?.current_crop_stage || '');
+        setSoilType(loaded?.soil_type || '');
+        setFarmStorySummary(loaded?.farm_story_summary || '');
+        setAiManagerBrief(loaded?.ai_manager_brief || '');
+        setProfileStatus(loaded?.status || 'active');
+      })
+      .catch((loadError) => setError(errorMessage(loadError)))
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [farmer.farmer_id, farmer.preferred_language]);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const saved = await saveCoordinatorFarmerAiProfile({
+        farmerId: farmer.farmer_id,
+        preferredLanguage,
+        literacyLevel,
+        technologyComfort,
+        primaryGoal,
+        primaryPainPoint,
+        secondaryPainPoints: listFromText(secondaryPainPoints),
+        waterAccess,
+        irrigationMethod,
+        budgetConstraint,
+        labourConstraint,
+        mainCrops: listFromText(mainCrops),
+        currentCrop,
+        currentCropStage,
+        soilType,
+        farmStorySummary,
+        aiManagerBrief,
+        status: profileStatus,
+      });
+      setProfile(saved);
+      setAiManagerBrief(saved.ai_manager_brief || '');
+      setMessage('AI Farm Manager profile saved.');
+    } catch (saveError) {
+      setError(errorMessage(saveError));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="mt-5 border-t border-[#27653a]/30 pt-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-black text-[#27653a]">AI Farm Manager profile</p>
+          <p className="mt-1 text-xs text-gray-600">
+            Captures the farm story, pain points and constraints that will personalize this farmer’s AI agent.
+          </p>
+        </div>
+        <span className="border border-black bg-[#dff3d8] px-2 py-1 text-[10px] font-black uppercase">
+          {profile ? `brief v${profile.brief_version}` : 'not started'}
+        </span>
+      </div>
+
+      {message && <p className="mt-3 bg-[#dff3d8] p-2 text-sm font-bold">{message}</p>}
+      {error && <p className="mt-3 bg-red-50 p-2 text-sm font-bold text-red-800">{error}</p>}
+      {loading && <p className="mt-3 text-sm font-bold">Loading AI profile…</p>}
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <Field label="Current crop">
+          <input value={currentCrop} onChange={(event) => setCurrentCrop(event.target.value)} placeholder="Tomato" className="input" />
+        </Field>
+        <Field label="Crop stage">
+          <input value={currentCropStage} onChange={(event) => setCurrentCropStage(event.target.value)} placeholder="Flowering" className="input" />
+        </Field>
+        <Field label="Primary goal">
+          <input value={primaryGoal} onChange={(event) => setPrimaryGoal(event.target.value)} placeholder="Improve yield" className="input" />
+        </Field>
+        <Field label="Primary pain point">
+          <input value={primaryPainPoint} onChange={(event) => setPrimaryPainPoint(event.target.value)} placeholder="Water timing" className="input" />
+        </Field>
+        <Field label="Main crops">
+          <input value={mainCrops} onChange={(event) => setMainCrops(event.target.value)} placeholder="Tomato, maize" className="input" />
+        </Field>
+        <Field label="Other pain points">
+          <input value={secondaryPainPoints} onChange={(event) => setSecondaryPainPoints(event.target.value)} placeholder="Pest identification, record keeping" className="input" />
+        </Field>
+        <Field label="Water access">
+          <input value={waterAccess} onChange={(event) => setWaterAccess(event.target.value)} placeholder="Limited borehole irrigation" className="input" />
+        </Field>
+        <Field label="Irrigation method">
+          <input value={irrigationMethod} onChange={(event) => setIrrigationMethod(event.target.value)} placeholder="Bucket, drip, flood" className="input" />
+        </Field>
+        <Field label="Budget constraint">
+          <input value={budgetConstraint} onChange={(event) => setBudgetConstraint(event.target.value)} placeholder="Low input budget" className="input" />
+        </Field>
+        <Field label="Labour constraint">
+          <input value={labourConstraint} onChange={(event) => setLabourConstraint(event.target.value)} placeholder="Limited labour during weekdays" className="input" />
+        </Field>
+        <Field label="Soil type">
+          <input value={soilType} onChange={(event) => setSoilType(event.target.value)} placeholder="Unknown, sandy, clay..." className="input" />
+        </Field>
+        <Field label="AI language">
+          <select value={preferredLanguage} onChange={(event) => setPreferredLanguage(event.target.value as typeof preferredLanguage)} className="input">
+            <option value="sn-en">Shona + English</option>
+            <option value="sn">Shona</option>
+            <option value="en">English</option>
+          </select>
+        </Field>
+      </div>
+
+      <div className="mt-3 grid gap-3">
+        <Field label="Farm story summary">
+          <textarea
+            value={farmStorySummary}
+            onChange={(event) => setFarmStorySummary(event.target.value)}
+            placeholder="What has this farmer struggled with in recent seasons?"
+            className="input min-h-24"
+          />
+        </Field>
+        <Field label="AI Manager Brief">
+          <textarea
+            value={aiManagerBrief}
+            onChange={(event) => setAiManagerBrief(event.target.value)}
+            placeholder="Leave blank to auto-generate from the profile."
+            className="input min-h-24"
+          />
+        </Field>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-3">
+        <select value={profileStatus} onChange={(event) => setProfileStatus(event.target.value as typeof profileStatus)} className="input w-auto">
+          <option value="active">Active</option>
+          <option value="draft">Draft</option>
+          <option value="needs_update">Needs update</option>
+          <option value="archived">Archived</option>
+        </select>
+        <button
+          type="button"
+          disabled={working || saving || loading}
+          onClick={() => void save()}
+          className="bg-[#27653a] px-5 py-2 font-black text-white disabled:opacity-50"
+        >
+          {saving ? 'Saving AI profile…' : 'Save AI Farm Manager profile'}
+        </button>
+      </div>
+    </section>
+  );
+}
+
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <label className="block">
@@ -364,6 +570,13 @@ function Fact({ label, value }: { label: string; value: string }) {
       <p className="mt-1 font-black">{value}</p>
     </div>
   );
+}
+
+function listFromText(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
 function languageLabel(language: CoordinatorFarmer['preferred_language']) {

--- a/apps/web/src/screens/Login.tsx
+++ b/apps/web/src/screens/Login.tsx
@@ -3,6 +3,16 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { useNavigate } from "react-router-dom";
 import { PILOT_AGENT_ENABLED } from "../agent/api";
+import { isFarmerSite } from "../agent/siteMode";
+
+interface LoginContractContext {
+  isDeployed: boolean;
+  deployContract: () => Promise<void>;
+}
+
+interface LoginWalletContext {
+  isConnected: boolean;
+}
 
 export function Login({
   onConnect,
@@ -18,13 +28,14 @@ export function Login({
   isConnecting?: boolean;
   isWalletInstalled?: boolean;
   error?: string | null;
-  contractContext: any;
-  walletContext: any;
+  contractContext: LoginContractContext;
+  walletContext: LoginWalletContext;
   isDeploying: boolean;
   setIsDeploying: (deploying: boolean) => void;
 }) {
   const [deployError, setDeployError] = useState<string | null>(null);
   const navigate = useNavigate();
+  const farmerSite = isFarmerSite();
 
   const connectAndMaybeDeploy = async () => {
     setDeployError(null);
@@ -43,9 +54,9 @@ export function Login({
         await contractContext.deployContract();
         console.log("✅ Contract deployed successfully!");
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error("Connect/deploy failed:", err);
-      setDeployError(err?.message || "Failed to connect wallet or deploy contract");
+      setDeployError(errorMessage(err) || "Failed to connect wallet or deploy contract");
     } finally {
       setIsDeploying(false);
     }
@@ -82,7 +93,7 @@ export function Login({
           <Hero />
 
           <div className="text-xl font-[orbitron] font-bold text-end  absolute bottom-6 right-6 z-20">
-            {PILOT_AGENT_ENABLED && (
+            {PILOT_AGENT_ENABLED && !farmerSite && (
               <button
                 onClick={() => navigate('/pilot-login')}
                 className="mb-3 block w-[280px] border-2 border-black bg-[#f1d34f] px-6 py-4 text-base font-black text-black hover:bg-black hover:text-white"
@@ -146,4 +157,8 @@ export function Login({
       </div>
     </>
   );
+}
+
+function errorMessage(error: unknown): string | null {
+  return error instanceof Error ? error.message : null;
 }


### PR DESCRIPTION
## Summary

Adds the next AI Farm Manager pilot foundation: coordinator onboarding for farmer AI profiles, plus site-mode routing so EdgeChain can support separate funder and farmer experiences from the same codebase.

## What changed

- Added coordinator AI profile service.
- Added coordinator API endpoints:
  - `GET /api/v1/coordinator/farmers/:farmerId/ai-profile`
  - `PATCH /api/v1/coordinator/farmers/:farmerId/ai-profile`
- Added frontend `FarmerAiProfile` types.
- Added frontend API methods for loading/saving farmer AI profiles.
- Added AI Farm Manager profile editor inside Farmer Administration.
- Added fields for:
  - current crop
  - crop stage
  - primary goal
  - primary pain point
  - main crops
  - secondary pain points
  - water access
  - irrigation method
  - budget constraint
  - labour constraint
  - soil type
  - farm story summary
  - AI Manager Brief
  - profile status
- Added automatic backend AI Manager Brief generation when the coordinator leaves the brief blank.
- Added site-mode detection for farmer vs funder domains.
- Updated `/` routing:
  - farmer/pilot domains redirect to `/pilot-login`
  - funder/technical domains keep the wallet-first EdgeChain home
- Updated Fly deploy build config to use same-origin API calls for multi-domain support.

## Why

The pilot needs two different experiences:

1. Farmer pilot experience  
   Farmers should bypass wallet friction and access the AI Farm Manager / Ndani Kit pilot with farmer number + PIN.

2. Funder / technical experience  
   Funders should still see the full EdgeChain privacy, wallet, Midnight, federated-learning, and decentralization story.

This PR also lets coordinators capture the structured farm story and personalization fields needed for the AI Farm Manager to behave like a farmer-specific farm manager rather than a generic chatbot.

## Validation

- Backend build passed with Node 22.
- Frontend build passed with Node 22.
- Backend TypeScript `tsc --noEmit` passed.
- Targeted frontend ESLint passed.
- `git diff --check` passed.