### PR TITLE
Codex/enable ndani kit pilot

### DIFF
--- a/.github/workflows/deploy-flyio.yml
+++ b/.github/workflows/deploy-flyio.yml
@@ -63,14 +63,14 @@ jobs:
           VITE_MIDNIGHT_INDEXER_WS: wss://indexer.testnet-02.midnight.network/api/v1/graphql/ws
           VITE_MIDNIGHT_NODE_URL: https://rpc.testnet-02.midnight.network
           # Empty means same-origin API calls. This lets the same Fly app serve
-          # both funder and farmer custom domains without cross-domain cookies.
+          # both wallet-first and farmer custom domains without cross-domain cookies.
           VITE_API_URL: ''
           VITE_AGENT_ENABLED: 'true'
           VITE_VIRTUAL_NDANI_ENABLED: 'true'
           VITE_VIRTUAL_NDANI_COORDINATOR_ENABLED: 'true'
           VITE_VIRTUAL_NDANI_PHYSICAL_BINDING_ENABLED: 'false'
           VITE_VIRTUAL_NDANI_PIPELINE_DEMO_ENABLED: 'false'
-          VITE_FUNDER_SITE_HOSTS: ${{ vars.VITE_FUNDER_SITE_HOSTS }}
+          VITE_WALLET_SITE_HOSTS: ${{ vars.VITE_WALLET_SITE_HOSTS }}
           VITE_FARMER_SITE_HOSTS: ${{ vars.VITE_FARMER_SITE_HOSTS }}
 
       - name: Setup Fly CLI

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The current application intentionally supports two audiences from one codebase:
 
 | Experience | Entry point | Purpose |
 |------------|-------------|---------|
-| **Funder / technical EdgeChain** | `/` on funder-oriented domains | Wallet-first Midnight, privacy, federated learning, proof, and reward-eligibility story. |
+| **Technical EdgeChain** | `/` on wallet-first domains | Wallet-first Midnight, privacy, federated learning, proof, and reward-eligibility story. |
 | **Farmer pilot** | `/pilot-login` or `/` on farmer-oriented domains | Farmer number + PIN access to the AI Farm Manager, Virtual Ndani Kit, manual readings, and coordinator support without requiring wallet literacy on day one. |
 
 This is a staged adoption strategy, not a split vision. Farmers can receive immediate value through a low-friction pilot while EdgeChain continues toward farmer-controlled data, hardware identity, AI memory, privacy-preserving proofs, and federated model participation.
@@ -195,12 +195,12 @@ The circuit attests *"I know a valid P-256 signature from a registered device"* 
 
 The Odzi pilot now has two complementary goals:
 
-1. **Funder evidence:** show why EdgeChain’s long-term privacy, wallet, Midnight, hardware, and federated-learning architecture matters.
+1. **Technical evidence:** show why EdgeChain’s long-term privacy, wallet, Midnight, hardware, and federated-learning architecture matters.
 2. **Farmer buy-in:** show each pilot farmer that an AI Farm Manager can remember their farm, organize observations, advise practically, and follow up without forcing wallet usage on day one.
 
 ### Phase A - Farmer-first AI + Virtual Ndani Kit pilot
 
-Phase A delivers immediate farmer value and funder-grade documentation without requiring any Midnight transaction from pilot farmers. It is designed for a 20-farmer Odzi cohort using:
+Phase A delivers immediate farmer value and stakeholder-grade documentation without requiring any Midnight transaction from pilot farmers. It is designed for a 20-farmer Odzi cohort using:
 
 - farmer number + PIN login,
 - one coordinator/admin account,
@@ -245,7 +245,7 @@ Demonstrable today:
 - coordinator dashboard for fleet, farmer administration, review, evidence CSV, and operations metrics
 - farmer creation, update, PIN reset, deletion, and AI Farm Manager profile onboarding
 - AI Farm Manager data foundation: profiles, memories, weekly check-ins, AI plans, outcomes, and prompt invocation telemetry
-- domain/site-mode foundation for separate funder and farmer experiences
+- domain/site-mode foundation for separate wallet-first and farmer experiences
 - Two contracts deployed on Midnight testnet02
 - Live demo services on Fly.io
 - Freedom Node validated end-to-end in Maryland (Ubuntu Server 24.04 LTS + Docker + `midnightntwrk/proof-server:7.0.0`)
@@ -255,7 +255,7 @@ In progress before Phase B:
 
 - weekly AI Farm Manager check-ins and generated farm plans
 - memory-based Farm Assistant responses using structured Farm Manager Context Packs
-- farmer timeline and pilot/funder reports
+- farmer timeline and pilot/evidence reports
 - end-to-end ZK proof generation and submission across all live flows
 - full anonymous device registration and reward-eligibility path
 - reduction of simulated contract paths in the UI/backend
@@ -317,7 +317,7 @@ The unified Fly app serves both the React frontend and backend API. Code-level s
 
 | Domain type | Behavior |
 |-------------|----------|
-| Funder / technical domain | `/` remains wallet-first and highlights privacy, Midnight, federated learning, and proof infrastructure. |
+| Wallet-first / technical domain | `/` remains wallet-first and highlights privacy, Midnight, federated learning, and proof infrastructure. |
 | Farmer / pilot domain | `/` redirects to `/pilot-login` for farmer number + PIN access without wallet friction. |
 
 Custom domains still require Fly certificate and DNS configuration outside the repository.
@@ -395,7 +395,7 @@ VITE_VIRTUAL_NDANI_ENABLED=true
 VITE_VIRTUAL_NDANI_COORDINATOR_ENABLED=true
 VITE_VIRTUAL_NDANI_PHYSICAL_BINDING_ENABLED=false
 VITE_VIRTUAL_NDANI_PIPELINE_DEMO_ENABLED=false
-VITE_FUNDER_SITE_HOSTS=localhost,127.0.0.1
+VITE_WALLET_SITE_HOSTS=localhost,127.0.0.1
 VITE_FARMER_SITE_HOSTS=odzi.localhost,farmers.localhost,pilot.localhost
 ```
 
@@ -405,7 +405,7 @@ Useful local URLs:
 
 | URL | Purpose |
 |-----|---------|
-| `http://localhost:8080/` | funder / wallet-first home |
+| `http://localhost:8080/` | wallet-first home |
 | `http://localhost:8080/pilot-login` | farmer / coordinator PIN login |
 | `http://localhost:8080/coordinator` | coordinator dashboard after admin login |
 | `http://localhost:8080/virtual-ndani` | farmer Virtual Ndani Kit after farmer login |
@@ -517,7 +517,7 @@ TX power:           20
 | `DATABASE_URL` | PostgreSQL connection string used by the backend |
 | `DATABASE_SSL` | Set to `true` only when the Postgres provider requires SSL |
 | `PORT` | backend port |
-| `CORS_ORIGINS` | comma-separated allowed frontend origins; include any custom funder/farmer domains |
+| `CORS_ORIGINS` | comma-separated allowed frontend origins; include any custom wallet-first/farmer domains |
 | `DEMO_MODE` | mock fallback behavior |
 | `IPFS_SERVICE_URL` | URL for the Storacha/IPFS service |
 | `STORACHA_EMAIL` | IPFS auth |
@@ -543,7 +543,7 @@ TX power:           20
 | `VITE_VIRTUAL_NDANI_COORDINATOR_ENABLED` | enables coordinator UI |
 | `VITE_VIRTUAL_NDANI_PHYSICAL_BINDING_ENABLED` | enables future physical binding UI |
 | `VITE_VIRTUAL_NDANI_PIPELINE_DEMO_ENABLED` | enables optional pipeline demo UI |
-| `VITE_FUNDER_SITE_HOSTS` | comma-separated hostnames that should show the wallet/funder-first home |
+| `VITE_WALLET_SITE_HOSTS` | comma-separated hostnames that should show the wallet-first home |
 | `VITE_FARMER_SITE_HOSTS` | comma-separated hostnames that should route `/` to `/pilot-login` |
 | `VITE_CONTRACT_ADDRESS` | Midnight contract address for wallet-first flows |
 | `VITE_MIDNIGHT_INDEXER_URL`, `VITE_MIDNIGHT_INDEXER_WS`, `VITE_MIDNIGHT_NODE_URL` | Midnight testnet endpoints |
@@ -568,11 +568,11 @@ The backend stores operational data in PostgreSQL. The Fly volume is not used
 for database persistence; it can be removed later after the old attached volume
 is destroyed from Fly.
 
-When adding custom farmer/funder domains, update:
+When adding custom farmer/wallet-first domains, update:
 
 - Fly certificates and DNS outside the repository,
 - backend `CORS_ORIGINS`,
-- GitHub Actions repository variables `VITE_FUNDER_SITE_HOSTS` and `VITE_FARMER_SITE_HOSTS` if exact host matching is desired.
+- GitHub Actions repository variables `VITE_WALLET_SITE_HOSTS` and `VITE_FARMER_SITE_HOSTS` if exact host matching is desired.
 
 For Fly, create or attach Postgres before deploying:
 

--- a/apps/freedom-node/src/ai-farm-manager/checkinService.ts
+++ b/apps/freedom-node/src/ai-farm-manager/checkinService.ts
@@ -1,0 +1,172 @@
+import { authRepository } from '../auth/authRepository';
+import { virtualNdaniService } from '../virtual-ndani/service';
+import { FarmManagerRiskLevel, WeeklyFarmCheckin } from './domain';
+import { aiFarmManagerRepository } from './repository';
+
+const SOIL_CONDITIONS = ['very_dry', 'dry', 'moist', 'wet', 'waterlogged'] as const;
+const PLANT_CONDITIONS = ['good', 'fair', 'poor'] as const;
+const PEST_DISEASE_SIGNS = ['none', 'some', 'severe'] as const;
+const RAIN_CONDITIONS = ['no_recent_rain', 'light_recent_rain', 'heavy_recent_rain'] as const;
+const IRRIGATION_DONE = ['yes', 'no', 'not_needed'] as const;
+
+export class AiFarmManagerCheckinError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number
+  ) {
+    super(code);
+  }
+}
+
+export const aiFarmManagerCheckinService = {
+  async listForFarmer(farmerId: string): Promise<WeeklyFarmCheckin[]> {
+    return aiFarmManagerRepository.listCheckins({ farmerId, limit: 8 });
+  },
+
+  async createForFarmer(input: {
+    farmerId: string;
+    farmId?: unknown;
+    crop: unknown;
+    cropStage: unknown;
+    soilCondition: unknown;
+    plantCondition: unknown;
+    pestDiseaseSigns: unknown;
+    rainCondition: unknown;
+    irrigationDone: unknown;
+    farmerBiggestWorry: unknown;
+    labourOrInputConstraint: unknown;
+    followedPreviousAdvice: unknown;
+    observedChange: unknown;
+    manualNotes: unknown;
+  }): Promise<WeeklyFarmCheckin> {
+    const farm = await resolveFarm(input.farmerId, input.farmId);
+    const devices = await virtualNdaniService.list(input.farmerId);
+    const device = devices.find((candidate) => candidate.farm_id === farm.farm_id)
+      ?? devices[0]
+      ?? null;
+    const soilCondition = enumValue(
+      input.soilCondition,
+      SOIL_CONDITIONS,
+      'invalid_soil_condition'
+    );
+    const plantCondition = enumValue(
+      input.plantCondition,
+      PLANT_CONDITIONS,
+      'invalid_plant_condition'
+    );
+    const pestDiseaseSigns = enumValue(
+      input.pestDiseaseSigns,
+      PEST_DISEASE_SIGNS,
+      'invalid_pest_disease_signs'
+    );
+    const rainCondition = enumValue(
+      input.rainCondition,
+      RAIN_CONDITIONS,
+      'invalid_rain_condition'
+    );
+    const irrigationDone = enumValue(
+      input.irrigationDone,
+      IRRIGATION_DONE,
+      'invalid_irrigation_done'
+    );
+
+    return aiFarmManagerRepository.createCheckin({
+      farmerId: input.farmerId,
+      farmId: farm.farm_id,
+      virtualDeviceId: device?.virtual_device_id ?? null,
+      weekStart: startOfWeekEpoch(),
+      crop: optionalText(input.crop, 80),
+      cropStage: optionalText(input.cropStage, 80),
+      soilCondition,
+      plantCondition,
+      pestDiseaseSigns,
+      rainCondition,
+      irrigationDone,
+      farmerBiggestWorry: optionalText(input.farmerBiggestWorry, 400),
+      labourOrInputConstraint: optionalText(input.labourOrInputConstraint, 240),
+      followedPreviousAdvice: optionalBoolean(input.followedPreviousAdvice),
+      observedChange: optionalText(input.observedChange, 300),
+      manualNotes: optionalText(input.manualNotes, 600),
+      riskLevel: deriveRiskLevel({
+        soilCondition,
+        plantCondition,
+        pestDiseaseSigns,
+        rainCondition,
+        irrigationDone,
+      }),
+      createdBy: 'farmer',
+    });
+  },
+};
+
+async function resolveFarm(farmerId: string, requestedFarmId: unknown) {
+  const farms = await authRepository.listFarms(farmerId);
+  if (farms.length === 0) {
+    throw new AiFarmManagerCheckinError('farm_not_found', 404);
+  }
+  const farmId = optionalText(requestedFarmId, 80);
+  if (!farmId) return farms[0];
+  const farm = farms.find((candidate) => candidate.farm_id === farmId);
+  if (!farm) throw new AiFarmManagerCheckinError('farm_not_found', 404);
+  return farm;
+}
+
+function enumValue<T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  code: string
+): T[number] {
+  const candidate = String(value ?? '').trim();
+  if (allowed.includes(candidate)) return candidate as T[number];
+  throw new AiFarmManagerCheckinError(code, 400);
+}
+
+function optionalText(value: unknown, maxLength: number): string | null {
+  if (value === undefined || value === null) return null;
+  const text = String(value).trim();
+  if (!text) return null;
+  return text.slice(0, maxLength);
+}
+
+function optionalBoolean(value: unknown): boolean | null {
+  if (value === true || value === 'true') return true;
+  if (value === false || value === 'false') return false;
+  return null;
+}
+
+function deriveRiskLevel(input: {
+  soilCondition: string;
+  plantCondition: string;
+  pestDiseaseSigns: string;
+  rainCondition: string;
+  irrigationDone: string;
+}): FarmManagerRiskLevel {
+  if (
+    input.soilCondition === 'waterlogged'
+    || input.plantCondition === 'poor'
+    || input.pestDiseaseSigns === 'severe'
+  ) {
+    return 'high';
+  }
+  if (
+    input.soilCondition === 'very_dry'
+    || input.soilCondition === 'dry'
+    || input.plantCondition === 'fair'
+    || input.pestDiseaseSigns === 'some'
+    || (input.rainCondition === 'no_recent_rain' && input.irrigationDone === 'no')
+  ) {
+    return 'medium';
+  }
+  return 'low';
+}
+
+function startOfWeekEpoch(date = new Date()): number {
+  const utcMidnight = Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate()
+  );
+  const day = new Date(utcMidnight).getUTCDay();
+  const daysSinceMonday = (day + 6) % 7;
+  return Math.floor((utcMidnight - daysSinceMonday * 24 * 60 * 60 * 1000) / 1000);
+}

--- a/apps/freedom-node/src/index.ts
+++ b/apps/freedom-node/src/index.ts
@@ -17,6 +17,7 @@ import { whatsappRouter } from './routes/whatsapp';
 import { authRouter } from './routes/auth';
 import { farmsRouter } from './routes/farms';
 import { agentRouter } from './routes/agent';
+import { aiFarmManagerRouter } from './routes/aiFarmManager';
 import { virtualNdaniRouter } from './routes/virtualNdani';
 import { coordinatorRouter } from './routes/coordinator';
 import { physicalNdaniRouter } from './routes/physicalNdani';
@@ -108,6 +109,7 @@ if (process.env.AGENT_ENABLED === 'true') {
   app.use('/api/v1/auth', authRouter);
   app.use('/api/v1/farms', farmsRouter);
   app.use('/api/v1/agent', agentRouter);
+  app.use('/api/v1/ai-farm-manager', aiFarmManagerRouter);
   if (process.env.VIRTUAL_NDANI_ENABLED !== 'false') {
     app.use('/api/v1/virtual-ndani', virtualNdaniRouter);
     if (process.env.VIRTUAL_NDANI_COORDINATOR_ENABLED !== 'false') {

--- a/apps/freedom-node/src/routes/aiFarmManager.ts
+++ b/apps/freedom-node/src/routes/aiFarmManager.ts
@@ -1,0 +1,53 @@
+import { Router } from 'express';
+import { FarmerRequest, requireFarmerSession } from '../auth/authMiddleware';
+import {
+  AiFarmManagerCheckinError,
+  aiFarmManagerCheckinService,
+} from '../ai-farm-manager/checkinService';
+
+const router = Router();
+router.use(requireFarmerSession);
+
+router.get('/checkins', async (req: FarmerRequest, res) => {
+  try {
+    const checkins = await aiFarmManagerCheckinService.listForFarmer(
+      req.farmer!.farmer_id
+    );
+    return res.json({ success: true, checkins });
+  } catch (error) {
+    return handleError(error, res);
+  }
+});
+
+router.post('/checkins', async (req: FarmerRequest, res) => {
+  try {
+    const checkin = await aiFarmManagerCheckinService.createForFarmer({
+      farmerId: req.farmer!.farmer_id,
+      farmId: req.body.farm_id,
+      crop: req.body.crop,
+      cropStage: req.body.crop_stage,
+      soilCondition: req.body.soil_condition,
+      plantCondition: req.body.plant_condition,
+      pestDiseaseSigns: req.body.pest_disease_signs,
+      rainCondition: req.body.rain_condition,
+      irrigationDone: req.body.irrigation_done,
+      farmerBiggestWorry: req.body.farmer_biggest_worry,
+      labourOrInputConstraint: req.body.labour_or_input_constraint,
+      followedPreviousAdvice: req.body.followed_previous_advice,
+      observedChange: req.body.observed_change,
+      manualNotes: req.body.manual_notes,
+    });
+    return res.status(201).json({ success: true, checkin });
+  } catch (error) {
+    return handleError(error, res);
+  }
+});
+
+function handleError(error: unknown, res: any) {
+  if (error instanceof AiFarmManagerCheckinError) {
+    return res.status(error.status).json({ error: error.code });
+  }
+  return res.status(500).json({ error: 'ai_farm_manager_request_failed' });
+}
+
+export { router as aiFarmManagerRouter };

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -18,6 +18,8 @@ VITE_VIRTUAL_NDANI_ENABLED=false
 VITE_VIRTUAL_NDANI_COORDINATOR_ENABLED=false
 VITE_VIRTUAL_NDANI_PHYSICAL_BINDING_ENABLED=false
 VITE_VIRTUAL_NDANI_PIPELINE_DEMO_ENABLED=false
+VITE_WALLET_SITE_HOSTS=localhost,127.0.0.1
+VITE_FARMER_SITE_HOSTS=odzi.localhost,farmers.localhost,pilot.localhost
 
 # ZK Configuration Paths (relative to public dir)
 # These are copied during build - no need to change

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import { AggregationRoute } from "./routes/AggregationRoute";
 import { PredictionsRoute } from "./routes/PredictionsRoute";
 import { PilotLoginRoute } from "./routes/PilotLoginRoute";
 import { FarmAssistantRoute } from "./routes/FarmAssistantRoute";
+import { FarmCheckInRoute } from "./routes/FarmCheckInRoute";
 import { VirtualNdaniRoute } from "./routes/VirtualNdaniRoute";
 import { VirtualNdaniReadingRoute } from "./routes/VirtualNdaniReadingRoute";
 import { CoordinatorRoute } from "./routes/CoordinatorRoute";
@@ -44,6 +45,7 @@ export default function EdgeChainApp() {
             <Route path="/virtual-ndani" element={<VirtualNdaniRoute />} />
             <Route path="/virtual-ndani/reading" element={<VirtualNdaniReadingRoute />} />
             <Route path="/virtual-ndani/demo" element={<PhysicalNdaniDemoRoute />} />
+            <Route path="/farm-check-in" element={<FarmCheckInRoute />} />
             <Route path="/farm-assistant" element={<FarmAssistantRoute />} />
             <Route path="/coordinator" element={<CoordinatorRoute />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/apps/web/src/agent/api.ts
+++ b/apps/web/src/agent/api.ts
@@ -12,6 +12,8 @@ import type {
   CoordinatorFarmer,
   CoordinatorReadingReview,
   FarmerAiProfile,
+  WeeklyFarmCheckin,
+  WeeklyFarmCheckinDraft,
   PilotOperationsMetrics,
   PilotEvidenceReport,
   PhysicalBindingChallenge,
@@ -358,6 +360,33 @@ export async function saveCoordinatorFarmerAiProfile(input: {
     profile: FarmerAiProfile;
   };
   return body.profile;
+}
+
+export async function loadWeeklyFarmCheckins(): Promise<WeeklyFarmCheckin[]> {
+  const response = await request('/api/v1/ai-farm-manager/checkins', {
+    method: 'GET',
+  });
+  if (!response.ok) throw await toApiError(response);
+  const body = await response.json() as {
+    success: true;
+    checkins: WeeklyFarmCheckin[];
+  };
+  return body.checkins;
+}
+
+export async function saveWeeklyFarmCheckin(
+  draft: WeeklyFarmCheckinDraft
+): Promise<WeeklyFarmCheckin> {
+  const response = await request('/api/v1/ai-farm-manager/checkins', {
+    method: 'POST',
+    body: JSON.stringify(draft),
+  });
+  if (!response.ok) throw await toApiError(response);
+  const body = await response.json() as {
+    success: true;
+    checkin: WeeklyFarmCheckin;
+  };
+  return body.checkin;
 }
 
 export async function loadCoordinatorReviews(): Promise<CoordinatorReadingReview[]> {

--- a/apps/web/src/agent/siteMode.ts
+++ b/apps/web/src/agent/siteMode.ts
@@ -1,12 +1,12 @@
-export type EdgeChainSiteMode = 'farmer' | 'funder';
+export type EdgeChainSiteMode = 'farmer' | 'wallet';
 
 const configuredFarmerHosts = hostList(import.meta.env.VITE_FARMER_SITE_HOSTS);
-const configuredFunderHosts = hostList(import.meta.env.VITE_FUNDER_SITE_HOSTS);
+const configuredWalletHosts = hostList(import.meta.env.VITE_WALLET_SITE_HOSTS);
 
 export function siteMode(hostname = window.location.hostname): EdgeChainSiteMode {
   const normalized = hostname.toLowerCase();
   if (matchesHost(normalized, configuredFarmerHosts)) return 'farmer';
-  if (matchesHost(normalized, configuredFunderHosts)) return 'funder';
+  if (matchesHost(normalized, configuredWalletHosts)) return 'wallet';
   if (
     normalized.startsWith('farmer.')
     || normalized.startsWith('farmers.')
@@ -15,7 +15,7 @@ export function siteMode(hostname = window.location.hostname): EdgeChainSiteMode
   ) {
     return 'farmer';
   }
-  return 'funder';
+  return 'wallet';
 }
 
 export function isFarmerSite(hostname?: string): boolean {

--- a/apps/web/src/agent/types.ts
+++ b/apps/web/src/agent/types.ts
@@ -95,6 +95,46 @@ export interface FarmerAiProfile {
   updated_at: number;
 }
 
+export interface WeeklyFarmCheckin {
+  checkin_id: string;
+  farmer_id: string;
+  farm_id: string | null;
+  virtual_device_id: string | null;
+  week_start: number;
+  crop: string | null;
+  crop_stage: string | null;
+  soil_condition: 'very_dry' | 'dry' | 'moist' | 'wet' | 'waterlogged' | null;
+  plant_condition: 'good' | 'fair' | 'poor' | null;
+  pest_disease_signs: 'none' | 'some' | 'severe' | null;
+  rain_condition: 'no_recent_rain' | 'light_recent_rain' | 'heavy_recent_rain' | null;
+  irrigation_done: 'yes' | 'no' | 'not_needed' | null;
+  farmer_biggest_worry: string | null;
+  labour_or_input_constraint: string | null;
+  followed_previous_advice: boolean | null;
+  observed_change: string | null;
+  manual_notes: string | null;
+  risk_level: 'low' | 'medium' | 'high' | null;
+  created_by: 'farmer' | 'coordinator' | 'system';
+  created_at: number;
+  updated_at: number;
+}
+
+export interface WeeklyFarmCheckinDraft {
+  farm_id: string;
+  crop: string;
+  crop_stage: string;
+  soil_condition: NonNullable<WeeklyFarmCheckin['soil_condition']>;
+  plant_condition: NonNullable<WeeklyFarmCheckin['plant_condition']>;
+  pest_disease_signs: NonNullable<WeeklyFarmCheckin['pest_disease_signs']>;
+  rain_condition: NonNullable<WeeklyFarmCheckin['rain_condition']>;
+  irrigation_done: NonNullable<WeeklyFarmCheckin['irrigation_done']>;
+  farmer_biggest_worry: string;
+  labour_or_input_constraint: string;
+  followed_previous_advice: boolean | null;
+  observed_change: string;
+  manual_notes: string;
+}
+
 export interface PilotOperationsMetrics {
   devices: number;
   total_cycles: number;

--- a/apps/web/src/routes/FarmCheckInRoute.tsx
+++ b/apps/web/src/routes/FarmCheckInRoute.tsx
@@ -1,0 +1,31 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAgentSession } from '../agent/agentSessionContext';
+import { VIRTUAL_NDANI_ENABLED } from '../agent/api';
+import { FarmCheckIn } from '../screens/FarmCheckIn';
+import { PilotLoading } from './PilotLoginRoute';
+
+export function FarmCheckInRoute() {
+  const agent = useAgentSession();
+  const location = useLocation();
+
+  if (!VIRTUAL_NDANI_ENABLED) {
+    return <Navigate to="/farm-assistant" replace />;
+  }
+  if (agent.loading) {
+    return <PilotLoading label="Opening your weekly farm check-in…" />;
+  }
+  if (!agent.session) {
+    return (
+      <Navigate
+        to="/pilot-login"
+        state={{ from: location.pathname }}
+        replace
+      />
+    );
+  }
+  if (agent.session.farmer.system_role === 'coordinator') {
+    return <Navigate to="/coordinator" replace />;
+  }
+
+  return <FarmCheckIn session={agent.session} onLogout={agent.logout} />;
+}

--- a/apps/web/src/screens/FarmCheckIn.tsx
+++ b/apps/web/src/screens/FarmCheckIn.tsx
@@ -1,0 +1,460 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  loadWeeklyFarmCheckins,
+  saveWeeklyFarmCheckin,
+} from '../agent/api';
+import { PilotBrand } from '../agent/PilotBrand';
+import type {
+  PilotSession,
+  WeeklyFarmCheckin,
+  WeeklyFarmCheckinDraft,
+} from '../agent/types';
+
+const SOIL_OPTIONS = [
+  { value: 'very_dry', label: 'Very dry', shona: 'Kuoma zvakanyanya' },
+  { value: 'dry', label: 'Dry', shona: 'Kuoma' },
+  { value: 'moist', label: 'Moist', shona: 'Kunyorova' },
+  { value: 'wet', label: 'Wet', shona: 'Kunyanya kunyorova' },
+  { value: 'waterlogged', label: 'Waterlogged', shona: 'Mvura yakawandisa' },
+] as const;
+
+const PLANT_OPTIONS = [
+  { value: 'good', label: 'Good', shona: 'Zvakamira zvakanaka' },
+  { value: 'fair', label: 'Fair', shona: 'Zviri pakati' },
+  { value: 'poor', label: 'Poor', shona: 'Hazvina kumira zvakanaka' },
+] as const;
+
+const PEST_OPTIONS = [
+  { value: 'none', label: 'None seen', shona: 'Hapana zvaonekwa' },
+  { value: 'some', label: 'Some signs', shona: 'Zviripo zvishoma' },
+  { value: 'severe', label: 'Serious signs', shona: 'Zvakanyanya' },
+] as const;
+
+const RAIN_OPTIONS = [
+  { value: 'no_recent_rain', label: 'No recent rain', shona: 'Hakuna mvura ichangobva kunaya' },
+  { value: 'light_recent_rain', label: 'Light rain', shona: 'Mvura shoma' },
+  { value: 'heavy_recent_rain', label: 'Heavy rain', shona: 'Mvura yakawanda' },
+] as const;
+
+const IRRIGATION_OPTIONS = [
+  { value: 'yes', label: 'Yes', shona: 'Hongu' },
+  { value: 'no', label: 'No', shona: 'Kwete' },
+  { value: 'not_needed', label: 'Not needed', shona: 'Hazvina kudiwa' },
+] as const;
+
+const ADVICE_OPTIONS = [
+  { value: 'true', label: 'Yes', shona: 'Hongu' },
+  { value: 'false', label: 'No', shona: 'Kwete' },
+  { value: 'unknown', label: 'Not sure', shona: 'Handina chokwadi' },
+] as const;
+
+export function FarmCheckIn({
+  session,
+  onLogout,
+}: {
+  session: PilotSession;
+  onLogout: () => Promise<void>;
+}) {
+  const navigate = useNavigate();
+  const [farmId, setFarmId] = useState(session.farms[0]?.farm_id || '');
+  const [history, setHistory] = useState<WeeklyFarmCheckin[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<WeeklyFarmCheckin | null>(null);
+  const [draft, setDraft] = useState<WeeklyFarmCheckinDraft>({
+    farm_id: session.farms[0]?.farm_id || '',
+    crop: '',
+    crop_stage: '',
+    soil_condition: 'moist',
+    plant_condition: 'good',
+    pest_disease_signs: 'none',
+    rain_condition: 'no_recent_rain',
+    irrigation_done: 'not_needed',
+    farmer_biggest_worry: '',
+    labour_or_input_constraint: '',
+    followed_previous_advice: null,
+    observed_change: '',
+    manual_notes: '',
+  });
+
+  const selectedFarm = useMemo(
+    () => session.farms.find((farm) => farm.farm_id === farmId),
+    [session.farms, farmId]
+  );
+
+  useEffect(() => {
+    let active = true;
+    void loadWeeklyFarmCheckins()
+      .then((checkins) => {
+        if (active) setHistory(checkins);
+      })
+      .catch(() => {
+        if (active) setError('EdgeChain could not load previous check-ins.');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    setDraft((current) => ({ ...current, farm_id: farmId }));
+  }, [farmId]);
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!farmId || saving) return;
+    setSaving(true);
+    setError(null);
+    setSaved(null);
+    try {
+      const checkin = await saveWeeklyFarmCheckin({
+        ...draft,
+        farm_id: farmId,
+      });
+      setSaved(checkin);
+      setHistory((current) => [checkin, ...current].slice(0, 8));
+    } catch {
+      setError('This weekly check-in could not be saved. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (session.farms.length === 0) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#f4f1e8] p-6">
+        <section className="max-w-lg border-2 border-black bg-white p-8 shadow-[8px_8px_0_#000]">
+          <h1 className="text-3xl font-black">No farm assigned</h1>
+          <p className="mt-4 text-gray-700">
+            Ask the pilot coordinator to assign a farm to your farmer profile.
+          </p>
+          <button
+            onClick={() => void onLogout().then(() => navigate('/pilot-login'))}
+            className="mt-7 bg-black px-5 py-3 font-bold text-white"
+          >
+            Sign out
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-[#f4f1e8] px-4 pb-16 pt-20 text-[#171713] sm:px-6">
+      <div className="mx-auto max-w-6xl">
+        <header className="grid gap-5 border-b-2 border-black pb-7 md:grid-cols-[1fr_auto] md:items-end">
+          <div>
+            <PilotBrand compact />
+            <p className="mt-5 text-sm font-black uppercase tracking-[0.2em] text-[#27653a]">
+              Weekly Farm Check-in
+            </p>
+            <h1 className="mt-2 text-4xl font-black leading-none sm:text-5xl">
+              Teach your AI Farm Manager what changed this week
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg text-gray-700">
+              You enter observations manually. EdgeChain remembers, organizes,
+              and prepares them for personalized advice.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={() => navigate('/virtual-ndani')}
+              className="border-2 border-black bg-[#f1d34f] px-5 py-3 font-black"
+            >
+              My Virtual Ndani Kit
+            </button>
+            <button
+              type="button"
+              onClick={() => void onLogout().then(() => navigate('/pilot-login'))}
+              className="border-2 border-black bg-white px-5 py-3 font-black hover:bg-black hover:text-white"
+            >
+              Sign out
+            </button>
+          </div>
+        </header>
+
+        {error && (
+          <p role="alert" className="mt-6 border-l-4 border-red-700 bg-red-50 p-4 font-bold text-red-800">
+            {error}
+          </p>
+        )}
+        {saved && (
+          <section className="mt-6 border-2 border-black bg-[#dff3d8] p-5 shadow-[6px_6px_0_#000]">
+            <p className="text-sm font-black uppercase tracking-[0.18em] text-[#27653a]">
+              Check-in saved
+            </p>
+            <h2 className="mt-2 text-2xl font-black">
+              This week is marked as {riskLabel(saved.risk_level)} risk.
+            </h2>
+            <p className="mt-2 text-gray-700">
+              Next phase will use this record to generate a simple weekly farm plan.
+            </p>
+          </section>
+        )}
+
+        <section className="mt-7 grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+          <form onSubmit={submit} className="border-2 border-black bg-white p-5 shadow-[8px_8px_0_#000] sm:p-7">
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="block">
+                <span className="text-xs font-black uppercase tracking-wide">Farm</span>
+                <select
+                  value={farmId}
+                  onChange={(event) => setFarmId(event.target.value)}
+                  className="mt-2 w-full border-2 border-black bg-white px-3 py-3 font-bold"
+                >
+                  {session.farms.map((farm) => (
+                    <option key={farm.farm_id} value={farm.farm_id}>
+                      {farm.display_name} · {farm.site_id}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <TextField
+                label="Main crop this week"
+                value={draft.crop}
+                placeholder="e.g. maize, tomatoes"
+                onChange={(value) => setDraft((current) => ({ ...current, crop: value }))}
+              />
+              <TextField
+                label="Crop stage"
+                value={draft.crop_stage}
+                placeholder="e.g. flowering, early growth"
+                onChange={(value) => setDraft((current) => ({ ...current, crop_stage: value }))}
+              />
+              <TextField
+                label="Biggest worry"
+                value={draft.farmer_biggest_worry}
+                placeholder="What worries you most right now?"
+                onChange={(value) => setDraft((current) => ({ ...current, farmer_biggest_worry: value }))}
+              />
+            </div>
+
+            <OptionGroup
+              title="Soil condition"
+              options={SOIL_OPTIONS}
+              value={draft.soil_condition}
+              onChange={(value) => setDraft((current) => ({ ...current, soil_condition: value }))}
+            />
+            <OptionGroup
+              title="Plant condition"
+              options={PLANT_OPTIONS}
+              value={draft.plant_condition}
+              onChange={(value) => setDraft((current) => ({ ...current, plant_condition: value }))}
+            />
+            <OptionGroup
+              title="Pests or disease"
+              options={PEST_OPTIONS}
+              value={draft.pest_disease_signs}
+              onChange={(value) => setDraft((current) => ({ ...current, pest_disease_signs: value }))}
+            />
+            <OptionGroup
+              title="Rain this week"
+              options={RAIN_OPTIONS}
+              value={draft.rain_condition}
+              onChange={(value) => setDraft((current) => ({ ...current, rain_condition: value }))}
+            />
+            <OptionGroup
+              title="Did you irrigate?"
+              options={IRRIGATION_OPTIONS}
+              value={draft.irrigation_done}
+              onChange={(value) => setDraft((current) => ({ ...current, irrigation_done: value }))}
+            />
+            <OptionGroup
+              title="Did you follow the previous advice?"
+              options={ADVICE_OPTIONS}
+              value={adviceValue(draft.followed_previous_advice)}
+              onChange={(value) => setDraft((current) => ({
+                ...current,
+                followed_previous_advice:
+                  value === 'unknown' ? null : value === 'true',
+              }))}
+            />
+
+            <div className="mt-7 grid gap-4 md:grid-cols-2">
+              <TextArea
+                label="What changed?"
+                value={draft.observed_change}
+                placeholder="e.g. leaves yellowing, weeds increasing, plants recovering"
+                onChange={(value) => setDraft((current) => ({ ...current, observed_change: value }))}
+              />
+              <TextArea
+                label="Labour or input constraint"
+                value={draft.labour_or_input_constraint}
+                placeholder="e.g. no fertilizer, not enough labour, pump broken"
+                onChange={(value) => setDraft((current) => ({ ...current, labour_or_input_constraint: value }))}
+              />
+              <TextArea
+                label="Any other notes"
+                value={draft.manual_notes}
+                placeholder="Optional"
+                onChange={(value) => setDraft((current) => ({ ...current, manual_notes: value }))}
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={saving}
+              className="mt-7 w-full bg-[#183c28] px-5 py-4 text-left text-xl font-black text-white hover:bg-[#24583b] disabled:opacity-60"
+            >
+              {saving ? 'Saving check-in…' : 'Save weekly check-in'}
+            </button>
+          </form>
+
+          <aside className="space-y-5">
+            <section className="border-2 border-black bg-[#183c28] p-6 text-white">
+              <p className="text-xs font-black uppercase tracking-[0.18em] text-[#cbe7ba]">
+                Why this matters
+              </p>
+              <h2 className="mt-2 text-2xl font-black">This is your farm memory.</h2>
+              <p className="mt-4 leading-relaxed text-white/85">
+                Today, you record weekly observations. Next, Ndani Kit hardware
+                automates more readings. Future EdgeChain keeps this intelligence
+                record private and controlled by the farmer.
+              </p>
+            </section>
+
+            <section className="border-2 border-black bg-white p-6">
+              <p className="text-xs font-black uppercase tracking-[0.18em] text-gray-500">
+                Recent check-ins
+              </p>
+              {loading ? (
+                <p className="mt-4 font-bold">Loading…</p>
+              ) : history.length === 0 ? (
+                <p className="mt-4 text-gray-600">
+                  No weekly check-ins yet for {selectedFarm?.display_name ?? 'this farm'}.
+                </p>
+              ) : (
+                <ol className="mt-4 space-y-3">
+                  {history.slice(0, 4).map((checkin) => (
+                    <li key={checkin.checkin_id} className="border border-black p-3">
+                      <p className="font-black">{formatWeek(checkin.week_start)}</p>
+                      <p className="mt-1 text-sm text-gray-600">
+                        {checkin.crop || 'Crop not named'} · {pretty(checkin.soil_condition)} soil · {riskLabel(checkin.risk_level)} risk
+                      </p>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </section>
+          </aside>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function TextField({
+  label,
+  value,
+  placeholder,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-black uppercase tracking-wide">{label}</span>
+      <input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="mt-2 w-full border-2 border-black px-3 py-3 font-bold"
+      />
+    </label>
+  );
+}
+
+function TextArea({
+  label,
+  value,
+  placeholder,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-black uppercase tracking-wide">{label}</span>
+      <textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        rows={4}
+        className="mt-2 w-full border-2 border-black px-3 py-3 font-bold"
+      />
+    </label>
+  );
+}
+
+function OptionGroup<T extends string>({
+  title,
+  options,
+  value,
+  onChange,
+}: {
+  title: string;
+  options: readonly { value: T; label: string; shona: string }[];
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <fieldset className="mt-7">
+      <legend className="text-xs font-black uppercase tracking-wide">{title}</legend>
+      <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {options.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={`border-2 border-black p-4 text-left ${
+              value === option.value
+                ? 'bg-[#f1d34f] shadow-[4px_4px_0_#000]'
+                : 'bg-white hover:bg-[#f7f1d1]'
+            }`}
+          >
+            <span className="block font-black">{option.label}</span>
+            <span className="mt-1 block text-sm text-gray-700">({option.shona})</span>
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+function adviceValue(value: boolean | null): 'true' | 'false' | 'unknown' {
+  if (value === true) return 'true';
+  if (value === false) return 'false';
+  return 'unknown';
+}
+
+function riskLabel(risk: WeeklyFarmCheckin['risk_level']): string {
+  if (risk === 'high') return 'high';
+  if (risk === 'medium') return 'medium';
+  if (risk === 'low') return 'low';
+  return 'unknown';
+}
+
+function pretty(value: string | null): string {
+  if (!value) return 'unknown';
+  return value.replace(/_/g, ' ');
+}
+
+function formatWeek(epoch: number): string {
+  return new Date(epoch * 1000).toLocaleDateString([], {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}

--- a/apps/web/src/screens/VirtualNdani.tsx
+++ b/apps/web/src/screens/VirtualNdani.tsx
@@ -155,6 +155,13 @@ export function VirtualNdani({
               </button>
               <button
                 type="button"
+                onClick={() => navigate('/farm-check-in')}
+                className="border-2 border-[#f1d34f] px-5 py-4 text-left font-black text-[#f1d34f] hover:bg-[#f1d34f] hover:text-black"
+              >
+                Weekly farm check-in
+              </button>
+              <button
+                type="button"
                 disabled={starting}
                 onClick={async () => {
                   setStarting(true);


### PR DESCRIPTION
PR description:

### Summary

Adds Phase 3 of the AI Farm Manager pilot: a farmer-facing Weekly Farm Check-in flow that records structured weekly farm observations for future personalized AI farm planning.

### What changed

- Added `/api/v1/ai-farm-manager/checkins` backend routes.
- Added AI Farm Manager check-in service with validation and basic risk-level classification.
- Added `/farm-check-in` frontend route.
- Added Weekly Farm Check-in UI with Shona/English option labels.
- Linked the check-in flow from the Virtual Ndani Kit dashboard.
- Added frontend API helpers and TypeScript types for weekly check-ins.

### Why

This gives each farmer a simple recurring way to teach EdgeChain what is happening on their farm each week. The records become the personalization foundation for later AI-generated farm plans, follow-ups, and outcome tracking.

### Validation

- Backend TypeScript check passed.
- Backend build passed.
- Frontend ESLint on touched files passed.
- Frontend build passed.
- `git diff --check` passed.