### PR TITLE
Add weekly AI farm plans

### DIFF
--- a/apps/freedom-node/src/ai-farm-manager/weeklyPlanService.ts
+++ b/apps/freedom-node/src/ai-farm-manager/weeklyPlanService.ts
@@ -1,0 +1,244 @@
+import {
+  AiFarmPlan,
+  FarmerAiMemory,
+  FarmerAiProfile,
+  FarmManagerRecommendedAction,
+  FarmManagerRiskLevel,
+  WeeklyFarmCheckin,
+} from './domain';
+import { aiFarmManagerRepository } from './repository';
+
+const PROMPT_FAMILY = 'weekly_farm_manager_plan';
+const PROMPT_VERSION = 'deterministic-pilot-v1';
+
+export const aiFarmManagerWeeklyPlanService = {
+  async listForFarmer(farmerId: string): Promise<AiFarmPlan[]> {
+    return aiFarmManagerRepository.listPlans({ farmerId, limit: 8 });
+  },
+
+  async createFromCheckin(checkin: WeeklyFarmCheckin): Promise<AiFarmPlan> {
+    const [profile, memories, previousPlans] = await Promise.all([
+      aiFarmManagerRepository.getActiveProfile({
+        farmerId: checkin.farmer_id,
+        farmId: checkin.farm_id ?? undefined,
+      }),
+      aiFarmManagerRepository.listContextMemories({
+        farmerId: checkin.farmer_id,
+        farmId: checkin.farm_id ?? undefined,
+        limit: 6,
+      }),
+      aiFarmManagerRepository.listPlans({
+        farmerId: checkin.farmer_id,
+        farmId: checkin.farm_id ?? undefined,
+        limit: 2,
+      }),
+    ]);
+    const riskLevel = checkin.risk_level ?? 'medium';
+    const mainIssue = determineMainIssue(checkin, profile);
+    const actions = buildRecommendedActions(checkin, profile);
+    const missingInformation = missingInfo(checkin, profile);
+    const safetyFlags = safetyFlagsFor(checkin);
+
+    return aiFarmManagerRepository.createPlan({
+      farmerId: checkin.farmer_id,
+      farmId: checkin.farm_id,
+      checkinId: checkin.checkin_id,
+      promptFamily: PROMPT_FAMILY,
+      promptVersion: PROMPT_VERSION,
+      modelProvider: 'edgechain',
+      modelName: 'deterministic-weekly-plan-pilot',
+      riskLevel,
+      confidence: missingInformation.length > 2 ? 'medium' : 'high',
+      summary: buildSummary(checkin, profile, mainIssue),
+      mainIssue,
+      recommendedActions: actions,
+      simpleExplanation: buildSimpleExplanation(checkin, mainIssue),
+      shonaSummary: buildShonaSummary(checkin, mainIssue),
+      followUpQuestion: buildFollowUpQuestion(checkin, profile),
+      missingInformation,
+      evidenceUsed: [
+        {
+          type: 'checkin',
+          id: checkin.checkin_id,
+          summary: `Weekly check-in: soil ${pretty(checkin.soil_condition)}, plants ${pretty(checkin.plant_condition)}, pests ${pretty(checkin.pest_disease_signs)}.`,
+        },
+        ...(profile ? [{
+          type: 'profile' as const,
+          id: profile.profile_id,
+          summary: profile.ai_manager_brief || profile.farm_story_summary || 'AI Farm Manager profile.',
+        }] : []),
+        ...memories.slice(0, 3).map(memoryEvidence),
+        ...previousPlans.slice(0, 1).map((plan) => ({
+          type: 'previous_plan' as const,
+          id: plan.plan_id,
+          summary: plan.summary,
+        })),
+      ],
+      safetyFlags,
+      coordinatorReviewRequired: riskLevel === 'high' || safetyFlags.length > 0,
+      rawModelOutput: {
+        generator: 'deterministic',
+        note: 'Pilot-safe plan generated without external LLM call.',
+      },
+      validationStatus: 'valid',
+    });
+  },
+};
+
+function determineMainIssue(
+  checkin: WeeklyFarmCheckin,
+  profile?: FarmerAiProfile
+): string {
+  if (checkin.pest_disease_signs === 'severe') return 'serious pest or disease signs';
+  if (checkin.plant_condition === 'poor') return 'poor plant condition';
+  if (checkin.soil_condition === 'waterlogged') return 'too much water in the soil';
+  if (checkin.soil_condition === 'very_dry' || checkin.soil_condition === 'dry') {
+    return 'soil moisture stress';
+  }
+  if (checkin.pest_disease_signs === 'some') return 'early pest or disease signs';
+  if (checkin.labour_or_input_constraint) return 'input or labour constraint';
+  return profile?.primary_pain_point || checkin.farmer_biggest_worry || 'weekly crop monitoring';
+}
+
+function buildRecommendedActions(
+  checkin: WeeklyFarmCheckin,
+  profile?: FarmerAiProfile
+): FarmManagerRecommendedAction[] {
+  const actions: FarmManagerRecommendedAction[] = [];
+  if (checkin.soil_condition === 'very_dry' || checkin.soil_condition === 'dry') {
+    actions.push({
+      priority: 1,
+      title: 'Protect soil moisture',
+      action: 'Check soil early morning and irrigate if water is available. If possible, add mulch around the crop to reduce water loss.',
+      reason: 'Dry soil can stress the crop, especially at flowering or fruiting stage.',
+      timeframe: 'Today or tomorrow morning',
+      cost_level: profile?.budget_constraint ? 'low' : 'medium',
+      difficulty: 'moderate',
+      shona_phrase: 'Chengetedza hunyoro hwevhu.',
+    });
+  }
+  if (checkin.soil_condition === 'waterlogged') {
+    actions.push({
+      priority: 1,
+      title: 'Move excess water away',
+      action: 'Open small drainage paths where safe and avoid adding more water until the soil starts drying.',
+      reason: 'Too much water can damage roots and increase disease pressure.',
+      timeframe: 'Today',
+      cost_level: 'none',
+      difficulty: 'moderate',
+      shona_phrase: 'Deredza mvura yakawandisa mumunda.',
+    });
+  }
+  if (checkin.pest_disease_signs === 'some' || checkin.pest_disease_signs === 'severe') {
+    actions.push({
+      priority: actions.length + 1,
+      title: 'Scout for pests and disease',
+      action: 'Inspect leaves, stems, and fruit on at least five plants in different parts of the field. Take a photo or note where signs are worst.',
+      reason: 'Early identification helps the coordinator or AI assistant give safer, more specific next advice.',
+      timeframe: 'Within 24 hours',
+      cost_level: 'none',
+      difficulty: 'easy',
+      shona_phrase: 'Tarisa zvirwere nezvipembenene pamashizha.',
+    });
+  }
+  if (checkin.plant_condition === 'poor' || checkin.plant_condition === 'fair') {
+    actions.push({
+      priority: actions.length + 1,
+      title: 'Compare weak and strong plants',
+      action: 'Look for differences between weak plants and healthy plants: soil wetness, insects, leaf colour, weeds, or damage.',
+      reason: 'This gives the next AI plan better evidence instead of guessing.',
+      timeframe: 'This week',
+      cost_level: 'none',
+      difficulty: 'easy',
+      shona_phrase: 'Enzanisa zvirimwa zvisina kusimba nezvakasimba.',
+    });
+  }
+  if (checkin.labour_or_input_constraint) {
+    actions.push({
+      priority: actions.length + 1,
+      title: 'Work around the constraint',
+      action: `Plan one small action that fits the current constraint: ${checkin.labour_or_input_constraint}. Focus on the part of the field with the most risk first.`,
+      reason: 'A small realistic action is better than advice the farmer cannot afford or execute.',
+      timeframe: 'Before the next check-in',
+      cost_level: 'low',
+      difficulty: 'easy',
+      shona_phrase: 'Tanga nezvaunokwanisa kuita.',
+    });
+  }
+  if (actions.length === 0) {
+    actions.push({
+      priority: 1,
+      title: 'Keep monitoring',
+      action: 'Continue checking soil, plant colour, pests, and water once or twice this week. Record any change in the next check-in.',
+      reason: 'Stable conditions are useful evidence for the farm record.',
+      timeframe: 'This week',
+      cost_level: 'none',
+      difficulty: 'easy',
+      shona_phrase: 'Ramba uchiongorora munda.',
+    });
+  }
+  return actions.map((action, index) => ({ ...action, priority: index + 1 })).slice(0, 4);
+}
+
+function buildSummary(
+  checkin: WeeklyFarmCheckin,
+  profile: FarmerAiProfile | undefined,
+  mainIssue: string
+): string {
+  const crop = checkin.crop || profile?.current_crop || 'the current crop';
+  const stage = checkin.crop_stage || profile?.current_crop_stage;
+  return `${crop}${stage ? ` at ${stage} stage` : ''} needs attention for ${mainIssue}. Soil is ${pretty(checkin.soil_condition)}, plant condition is ${pretty(checkin.plant_condition)}, and pest/disease signs are ${pretty(checkin.pest_disease_signs)}.`;
+}
+
+function buildSimpleExplanation(checkin: WeeklyFarmCheckin, mainIssue: string): string {
+  return `The main thing this week is ${mainIssue}. This plan is based only on what was recorded in the weekly check-in and stored farm profile, so it avoids pretending to know unmeasured facts.`;
+}
+
+function buildShonaSummary(checkin: WeeklyFarmCheckin, mainIssue: string): string {
+  const risk = checkin.risk_level === 'high'
+    ? 'Njodzi yakakwira'
+    : checkin.risk_level === 'medium'
+      ? 'Njodzi iri pakati'
+      : 'Njodzi yakaderera';
+  return `${risk}. Chinhu chikuru svondo rino: ${mainIssue}. Tarisa munda uye nyora zvachinja.`;
+}
+
+function buildFollowUpQuestion(
+  checkin: WeeklyFarmCheckin,
+  profile?: FarmerAiProfile
+): string {
+  if (!checkin.crop && !profile?.current_crop) return 'Which crop should your AI Farm Manager focus on this week?';
+  if (checkin.pest_disease_signs !== 'none') return 'Can you describe or photograph the pest or disease signs you saw?';
+  if (checkin.soil_condition === 'dry' || checkin.soil_condition === 'very_dry') return 'How many times can you realistically irrigate before the next check-in?';
+  if (checkin.labour_or_input_constraint) return 'Which part of the field can you manage first with the labour or inputs available?';
+  return 'What one change should I check again with you next week?';
+}
+
+function missingInfo(checkin: WeeklyFarmCheckin, profile?: FarmerAiProfile): string[] {
+  const missing: string[] = [];
+  if (!checkin.crop && !profile?.current_crop) missing.push('current crop');
+  if (!checkin.crop_stage && !profile?.current_crop_stage) missing.push('crop stage');
+  if (!profile?.water_access) missing.push('water access');
+  if (!profile?.soil_type) missing.push('soil type');
+  return missing;
+}
+
+function safetyFlagsFor(checkin: WeeklyFarmCheckin): string[] {
+  const flags: string[] = [];
+  if (checkin.pest_disease_signs === 'severe') flags.push('severe_pest_or_disease_signs');
+  if (checkin.plant_condition === 'poor') flags.push('poor_plant_condition');
+  if (checkin.soil_condition === 'waterlogged') flags.push('waterlogging_risk');
+  return flags;
+}
+
+function memoryEvidence(memory: FarmerAiMemory) {
+  return {
+    type: 'memory' as const,
+    id: memory.memory_id,
+    summary: `${memory.memory_key}: ${memory.memory_value}`,
+  };
+}
+
+function pretty(value: string | null): string {
+  return value ? value.replace(/_/g, ' ') : 'not recorded';
+}

--- a/apps/freedom-node/src/routes/aiFarmManager.ts
+++ b/apps/freedom-node/src/routes/aiFarmManager.ts
@@ -4,6 +4,7 @@ import {
   AiFarmManagerCheckinError,
   aiFarmManagerCheckinService,
 } from '../ai-farm-manager/checkinService';
+import { aiFarmManagerWeeklyPlanService } from '../ai-farm-manager/weeklyPlanService';
 
 const router = Router();
 router.use(requireFarmerSession);
@@ -37,7 +38,19 @@ router.post('/checkins', async (req: FarmerRequest, res) => {
       observedChange: req.body.observed_change,
       manualNotes: req.body.manual_notes,
     });
-    return res.status(201).json({ success: true, checkin });
+    const plan = await aiFarmManagerWeeklyPlanService.createFromCheckin(checkin);
+    return res.status(201).json({ success: true, checkin, plan });
+  } catch (error) {
+    return handleError(error, res);
+  }
+});
+
+router.get('/plans', async (req: FarmerRequest, res) => {
+  try {
+    const plans = await aiFarmManagerWeeklyPlanService.listForFarmer(
+      req.farmer!.farmer_id
+    );
+    return res.json({ success: true, plans });
   } catch (error) {
     return handleError(error, res);
   }

--- a/apps/web/src/agent/api.ts
+++ b/apps/web/src/agent/api.ts
@@ -12,6 +12,7 @@ import type {
   CoordinatorFarmer,
   CoordinatorReadingReview,
   FarmerAiProfile,
+  AiFarmPlan,
   WeeklyFarmCheckin,
   WeeklyFarmCheckinDraft,
   PilotOperationsMetrics,
@@ -374,9 +375,21 @@ export async function loadWeeklyFarmCheckins(): Promise<WeeklyFarmCheckin[]> {
   return body.checkins;
 }
 
+export async function loadAiFarmPlans(): Promise<AiFarmPlan[]> {
+  const response = await request('/api/v1/ai-farm-manager/plans', {
+    method: 'GET',
+  });
+  if (!response.ok) throw await toApiError(response);
+  const body = await response.json() as {
+    success: true;
+    plans: AiFarmPlan[];
+  };
+  return body.plans;
+}
+
 export async function saveWeeklyFarmCheckin(
   draft: WeeklyFarmCheckinDraft
-): Promise<WeeklyFarmCheckin> {
+): Promise<{ checkin: WeeklyFarmCheckin; plan: AiFarmPlan }> {
   const response = await request('/api/v1/ai-farm-manager/checkins', {
     method: 'POST',
     body: JSON.stringify(draft),
@@ -385,8 +398,9 @@ export async function saveWeeklyFarmCheckin(
   const body = await response.json() as {
     success: true;
     checkin: WeeklyFarmCheckin;
+    plan: AiFarmPlan;
   };
-  return body.checkin;
+  return { checkin: body.checkin, plan: body.plan };
 }
 
 export async function loadCoordinatorReviews(): Promise<CoordinatorReadingReview[]> {

--- a/apps/web/src/agent/types.ts
+++ b/apps/web/src/agent/types.ts
@@ -135,6 +135,48 @@ export interface WeeklyFarmCheckinDraft {
   manual_notes: string;
 }
 
+export interface FarmManagerRecommendedAction {
+  priority: number;
+  title: string;
+  action: string;
+  reason: string;
+  timeframe: string;
+  cost_level: 'none' | 'low' | 'medium' | 'high';
+  difficulty: 'easy' | 'moderate' | 'difficult';
+  shona_phrase?: string;
+}
+
+export interface AiFarmPlan {
+  plan_id: string;
+  farmer_id: string;
+  farm_id: string | null;
+  checkin_id: string | null;
+  conversation_id: string | null;
+  prompt_family: string;
+  prompt_version: string;
+  model_provider: string;
+  model_name: string;
+  risk_level: 'low' | 'medium' | 'high';
+  confidence: 'low' | 'medium' | 'high';
+  summary: string;
+  main_issue: string | null;
+  recommended_actions: FarmManagerRecommendedAction[];
+  simple_explanation: string | null;
+  shona_summary: string | null;
+  follow_up_question: string | null;
+  missing_information: string[];
+  evidence_used: Array<{
+    type: 'profile' | 'memory' | 'checkin' | 'ndani_reading' | 'previous_plan' | 'playbook';
+    id: string;
+    summary: string;
+  }>;
+  safety_flags: string[];
+  coordinator_review_required: boolean;
+  raw_model_output: Record<string, unknown> | null;
+  validation_status: 'valid' | 'repaired' | 'fallback' | 'rejected';
+  created_at: number;
+}
+
 export interface PilotOperationsMetrics {
   devices: number;
   total_cycles: number;

--- a/apps/web/src/screens/FarmCheckIn.tsx
+++ b/apps/web/src/screens/FarmCheckIn.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
+  loadAiFarmPlans,
   loadWeeklyFarmCheckins,
   saveWeeklyFarmCheckin,
 } from '../agent/api';
 import { PilotBrand } from '../agent/PilotBrand';
 import type {
   PilotSession,
+  AiFarmPlan,
   WeeklyFarmCheckin,
   WeeklyFarmCheckinDraft,
 } from '../agent/types';
@@ -63,6 +65,8 @@ export function FarmCheckIn({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState<WeeklyFarmCheckin | null>(null);
+  const [plan, setPlan] = useState<AiFarmPlan | null>(null);
+  const [plans, setPlans] = useState<AiFarmPlan[]>([]);
   const [draft, setDraft] = useState<WeeklyFarmCheckinDraft>({
     farm_id: session.farms[0]?.farm_id || '',
     crop: '',
@@ -86,12 +90,17 @@ export function FarmCheckIn({
 
   useEffect(() => {
     let active = true;
-    void loadWeeklyFarmCheckins()
-      .then((checkins) => {
-        if (active) setHistory(checkins);
+    void Promise.all([
+      loadWeeklyFarmCheckins(),
+      loadAiFarmPlans(),
+    ])
+      .then(([checkins, farmPlans]) => {
+        if (!active) return;
+        setHistory(checkins);
+        setPlans(farmPlans);
       })
       .catch(() => {
-        if (active) setError('EdgeChain could not load previous check-ins.');
+        if (active) setError('EdgeChain could not load previous check-ins and plans.');
       })
       .finally(() => {
         if (active) setLoading(false);
@@ -111,15 +120,19 @@ export function FarmCheckIn({
     setSaving(true);
     setError(null);
     setSaved(null);
+    setPlan(null);
     try {
-      const checkin = await saveWeeklyFarmCheckin({
+      const result = await saveWeeklyFarmCheckin({
         ...draft,
         farm_id: farmId,
       });
+      const { checkin, plan: weeklyPlan } = result;
       setSaved(checkin);
+      setPlan(weeklyPlan);
       setHistory((current) => [checkin, ...current].slice(0, 8));
+      setPlans((current) => [weeklyPlan, ...current].slice(0, 8));
     } catch {
-      setError('This weekly check-in could not be saved. Please try again.');
+      setError('This weekly check-in and plan could not be saved. Please try again.');
     } finally {
       setSaving(false);
     }
@@ -184,17 +197,48 @@ export function FarmCheckIn({
             {error}
           </p>
         )}
-        {saved && (
+        {saved && plan && (
           <section className="mt-6 border-2 border-black bg-[#dff3d8] p-5 shadow-[6px_6px_0_#000]">
             <p className="text-sm font-black uppercase tracking-[0.18em] text-[#27653a]">
-              Check-in saved
+              Your weekly farm plan
             </p>
             <h2 className="mt-2 text-2xl font-black">
-              This week is marked as {riskLabel(saved.risk_level)} risk.
+              {plan.summary}
             </h2>
-            <p className="mt-2 text-gray-700">
-              Next phase will use this record to generate a simple weekly farm plan.
+            <p className="mt-2 font-bold text-[#27653a]">
+              Risk: {riskLabel(plan.risk_level)} · Confidence: {plan.confidence}
+              {plan.coordinator_review_required ? ' · Coordinator review recommended' : ''}
             </p>
+            {plan.simple_explanation && (
+              <p className="mt-3 text-gray-700">{plan.simple_explanation}</p>
+            )}
+            {plan.shona_summary && (
+              <p className="mt-3 border-l-4 border-[#27653a] bg-white p-3 font-bold">
+                {plan.shona_summary}
+              </p>
+            )}
+            <ol className="mt-5 grid gap-3 md:grid-cols-2">
+              {plan.recommended_actions.map((action) => (
+                <li key={`${plan.plan_id}-${action.priority}`} className="border border-black bg-white p-4">
+                  <p className="text-xs font-black uppercase text-gray-500">
+                    Action {action.priority} · {action.timeframe}
+                  </p>
+                  <h3 className="mt-1 font-black">{action.title}</h3>
+                  <p className="mt-2 text-sm">{action.action}</p>
+                  <p className="mt-2 text-xs text-gray-600">{action.reason}</p>
+                  {action.shona_phrase && (
+                    <p className="mt-2 text-sm font-bold text-[#27653a]">
+                      {action.shona_phrase}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ol>
+            {plan.follow_up_question && (
+              <p className="mt-4 border-2 border-black bg-[#f1d34f] p-3 font-black">
+                Follow-up: {plan.follow_up_question}
+              </p>
+            )}
           </section>
         )}
 
@@ -336,6 +380,30 @@ export function FarmCheckIn({
                       <p className="font-black">{formatWeek(checkin.week_start)}</p>
                       <p className="mt-1 text-sm text-gray-600">
                         {checkin.crop || 'Crop not named'} · {pretty(checkin.soil_condition)} soil · {riskLabel(checkin.risk_level)} risk
+                      </p>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </section>
+
+            <section className="border-2 border-black bg-white p-6">
+              <p className="text-xs font-black uppercase tracking-[0.18em] text-gray-500">
+                Recent AI plans
+              </p>
+              {loading ? (
+                <p className="mt-4 font-bold">Loading…</p>
+              ) : plans.length === 0 ? (
+                <p className="mt-4 text-gray-600">
+                  No weekly plans yet.
+                </p>
+              ) : (
+                <ol className="mt-4 space-y-3">
+                  {plans.slice(0, 3).map((farmPlan) => (
+                    <li key={farmPlan.plan_id} className="border border-black p-3">
+                      <p className="font-black">{farmPlan.main_issue || 'Weekly plan'}</p>
+                      <p className="mt-1 text-sm text-gray-600">
+                        {riskLabel(farmPlan.risk_level)} risk · {farmPlan.recommended_actions.length} actions
                       </p>
                     </li>
                   ))}


### PR DESCRIPTION
PR description:

### Summary

Adds Phase 4 of the AI Farm Manager pilot: weekly AI farm plans generated from farmer check-ins and stored as auditable farm intelligence records.

### What changed

- Added deterministic weekly AI farm plan generation.
- Extended check-in submission so saving a weekly check-in also creates a weekly farm plan.
- Added `GET /api/v1/ai-farm-manager/plans`.
- Added frontend types and API helpers for AI farm plans.
- Updated `/farm-check-in` to show:
  - farm summary
  - risk level
  - confidence
  - recommended actions
  - Shona summary
  - follow-up question
  - coordinator review flag
- Added a “Recent AI plans” section.

### Why

This makes the pilot feel like a real individualized AI Farm Manager experience, not just data entry. Each farmer now receives practical, farm-specific next steps immediately after a weekly check-in, while EdgeChain stores the plan, evidence, prompt version, and review metadata for auditability and future Gemini integration.

### Validation

- Backend TypeScript passed.
- Backend build passed.
- Frontend ESLint passed.
- Frontend build passed.
