### PR TITLE
Add memory-based Farm Manager chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ TX power:           20
 | `AI_FARM_MANAGER_LLM_ENABLED` | set to `true` to let weekly AI Farm Manager plans call Gemini; otherwise deterministic fallback plans are used |
 | `AI_FARM_MANAGER_TEMPERATURE` / `AI_FARM_MANAGER_TOP_P` | optional Gemini sampling controls for weekly farm plans |
 | `AI_FARM_MANAGER_MAX_OUTPUT_TOKENS` | optional weekly farm plan output cap; defaults to 1200 |
+| `AI_FARM_MANAGER_CHAT_MAX_OUTPUT_TOKENS` | optional memory-based Farm Assistant chat output cap; defaults to 800 |
 
 ### Frontend (`apps/web/`)
 

--- a/apps/freedom-node/src/ai-farm-manager/chatGateway.ts
+++ b/apps/freedom-node/src/ai-farm-manager/chatGateway.ts
@@ -1,0 +1,138 @@
+import { CHAT_OUTPUT_SCHEMA, CHAT_PROMPT_FAMILY, CHAT_PROMPT_VERSION, buildChatPrompt } from './chatPrompt';
+import type { FarmManagerChatContextPack } from './chatService';
+
+const DEFAULT_MODEL = 'gemini-2.5-flash-lite';
+const DEFAULT_TIMEOUT_MS = 12_000;
+
+export interface ChatModelResult {
+  provider: 'gemini' | 'edgechain';
+  model: string;
+  promptFamily: string;
+  promptVersion: string;
+  status: 'success' | 'fallback' | 'error';
+  output?: unknown;
+  errorCode?: string;
+  latencyMs: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  estimatedCostUsd?: number;
+}
+
+export const chatGateway = {
+  async generate(pack: FarmManagerChatContextPack): Promise<ChatModelResult> {
+    const started = Date.now();
+    const apiKey = process.env.GEMINI_API_KEY;
+    const enabled = process.env.AI_FARM_MANAGER_LLM_ENABLED === 'true';
+    const model = process.env.GEMINI_TEXT_MODEL || DEFAULT_MODEL;
+    if (!enabled || !apiKey) {
+      return fallbackResult(started, model, enabled ? 'missing_api_key' : 'llm_disabled');
+    }
+    const timeoutMs = positiveInteger(process.env.GEMINI_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch('https://generativelanguage.googleapis.com/v1beta/interactions', {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': apiKey,
+        },
+        body: JSON.stringify({
+          model,
+          input: buildChatPrompt(pack),
+          temperature: Number(process.env.AI_FARM_MANAGER_TEMPERATURE || 0.25),
+          top_p: Number(process.env.AI_FARM_MANAGER_TOP_P || 0.8),
+          max_output_tokens: positiveInteger(
+            process.env.AI_FARM_MANAGER_CHAT_MAX_OUTPUT_TOKENS,
+            800
+          ),
+          response_format: {
+            type: 'text',
+            mime_type: 'application/json',
+            schema: CHAT_OUTPUT_SCHEMA,
+          },
+        }),
+      });
+      if (!response.ok) throw new Error(`gemini_http_${response.status}`);
+      const body = await response.json() as Record<string, unknown>;
+      const usage = extractUsage(body);
+      return {
+        provider: 'gemini',
+        model,
+        promptFamily: CHAT_PROMPT_FAMILY,
+        promptVersion: CHAT_PROMPT_VERSION,
+        status: 'success',
+        output: JSON.parse(extractOutputText(body)),
+        latencyMs: Date.now() - started,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        estimatedCostUsd: estimateGeminiCost(usage.inputTokens, usage.outputTokens),
+      };
+    } catch (error) {
+      return {
+        ...fallbackResult(
+          started,
+          model,
+          error instanceof Error && error.name === 'AbortError'
+            ? 'gemini_timeout'
+            : error instanceof Error
+              ? error.message
+              : 'gemini_error'
+        ),
+        status: 'error',
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  },
+};
+
+function fallbackResult(started: number, model: string, errorCode: string): ChatModelResult {
+  return {
+    provider: 'edgechain',
+    model: 'deterministic-chat-pilot',
+    promptFamily: CHAT_PROMPT_FAMILY,
+    promptVersion: CHAT_PROMPT_VERSION,
+    status: 'fallback',
+    errorCode: `${errorCode}:${model}`,
+    latencyMs: Date.now() - started,
+    estimatedCostUsd: 0,
+  };
+}
+
+function extractOutputText(body: Record<string, unknown>): string {
+  if (typeof body.output_text === 'string') return body.output_text;
+  if (typeof body.outputText === 'string') return body.outputText;
+  throw new Error('gemini_missing_output_text');
+}
+
+function extractUsage(body: Record<string, unknown>): {
+  inputTokens?: number;
+  outputTokens?: number;
+} {
+  const usage = isRecord(body.usage) ? body.usage : {};
+  return {
+    inputTokens: numberValue(usage.input_tokens ?? usage.inputTokenCount),
+    outputTokens: numberValue(usage.output_tokens ?? usage.outputTokenCount),
+  };
+}
+
+function estimateGeminiCost(inputTokens?: number, outputTokens?: number): number {
+  const inputPerMillion = Number(process.env.GEMINI_INPUT_USD_PER_MILLION || 0.10);
+  const outputPerMillion = Number(process.env.GEMINI_OUTPUT_USD_PER_MILLION || 0.40);
+  return ((inputTokens || 0) * inputPerMillion + (outputTokens || 0) * outputPerMillion) / 1_000_000;
+}
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/freedom-node/src/ai-farm-manager/chatPrompt.ts
+++ b/apps/freedom-node/src/ai-farm-manager/chatPrompt.ts
@@ -1,0 +1,57 @@
+import type { FarmManagerChatContextPack } from './chatService';
+
+export const CHAT_PROMPT_FAMILY = 'farm_manager_memory_chat';
+export const CHAT_PROMPT_VERSION = '1.0.0';
+
+export const CHAT_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    answer: { type: 'string' },
+    shona_summary: { type: 'string' },
+    personalization_used: { type: 'array', items: { type: 'string' } },
+    recommended_next_step: { type: 'string' },
+    missing_information: { type: 'array', items: { type: 'string' } },
+    evidence_used: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          type: { type: 'string', enum: ['profile', 'memory', 'checkin', 'ndani_reading', 'previous_plan', 'playbook'] },
+          id: { type: 'string' },
+          summary: { type: 'string' },
+        },
+        required: ['type', 'id', 'summary'],
+      },
+    },
+    confidence: { type: 'string', enum: ['low', 'medium', 'high'] },
+    coordinator_review_required: { type: 'boolean' },
+    safety_flags: { type: 'array', items: { type: 'string' } },
+  },
+  required: [
+    'answer',
+    'recommended_next_step',
+    'missing_information',
+    'evidence_used',
+    'confidence',
+    'coordinator_review_required',
+    'safety_flags',
+  ],
+};
+
+export function buildChatPrompt(pack: FarmManagerChatContextPack): string {
+  return [
+    'You are EdgeChain AI Farm Manager for the Odzi farmer pilot.',
+    'Answer the farmer as a practical farm manager who knows this specific farm.',
+    'Use only the Farm Manager Context Pack. Do not invent farm facts, weather, prices, sensor readings, diseases, or measurements.',
+    'Clearly distinguish human observations from hardware readings.',
+    'Use simple language and include Shona when preferred_language is sn or sn-en.',
+    'If the farmer asks for chemical, dosage, expensive, uncertain, or severe disease advice, give safe general guidance and require coordinator review.',
+    '',
+    'Farm Manager Context Pack JSON:',
+    JSON.stringify(pack, null, 2),
+    '',
+    'Task:',
+    'Answer the farmer question. Use relevant farm profile, recent check-ins, recent plans, constraints, and memories.',
+    'Mention missing information if needed. Return valid JSON only.',
+  ].join('\n');
+}

--- a/apps/freedom-node/src/ai-farm-manager/chatService.ts
+++ b/apps/freedom-node/src/ai-farm-manager/chatService.ts
@@ -1,0 +1,278 @@
+import { authRepository } from '../auth/authRepository';
+import { FarmerFarm } from '../auth/authRepository';
+import {
+  AiFarmPlan,
+  FarmerAiMemory,
+  FarmerAiProfile,
+  FarmManagerConfidence,
+  FarmManagerEvidenceUsed,
+  WeeklyFarmCheckin,
+} from './domain';
+import { aiFarmManagerRepository } from './repository';
+import { chatGateway } from './chatGateway';
+import { CHAT_PROMPT_FAMILY, CHAT_PROMPT_VERSION } from './chatPrompt';
+import {
+  ChatValidationError,
+  ValidatedFarmManagerChatOutput,
+  validateFarmManagerChatOutput,
+} from './chatValidation';
+
+export interface FarmManagerChatContextPack {
+  context_pack_version: 'farm-manager-chat-context-v1';
+  farmer: {
+    farmer_id: string;
+    preferred_language: string;
+  };
+  farm: {
+    farm_id: string;
+    name: string;
+    site_id: string;
+  };
+  ai_profile: FarmerAiProfile | null;
+  recent_checkins: WeeklyFarmCheckin[];
+  important_memories: FarmerAiMemory[];
+  recent_plans: AiFarmPlan[];
+  farmer_question: string;
+}
+
+export interface FarmManagerChatReply {
+  answer: string;
+  shona_summary: string | null;
+  recommended_next_step: string | null;
+  missing_information: string[];
+  evidence_used: FarmManagerEvidenceUsed[];
+  confidence: FarmManagerConfidence;
+  coordinator_review_required: boolean;
+  safety_flags: string[];
+  provider: string;
+  model: string;
+  validation_status: 'valid' | 'fallback';
+}
+
+export class FarmManagerChatError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number
+  ) {
+    super(code);
+  }
+}
+
+export const farmManagerChatService = {
+  async reply(input: {
+    farmerId: string;
+    farmId: string;
+    text: string;
+    preferredLanguage?: string;
+  }): Promise<FarmManagerChatReply> {
+    const text = String(input.text ?? '').trim();
+    if (!text || text.length > 2_000) {
+      throw new FarmManagerChatError('message_must_contain_1_to_2000_characters', 400);
+    }
+    const farm = await resolveFarm(input.farmerId, input.farmId);
+    const pack = await buildChatContextPack({
+      farmerId: input.farmerId,
+      farm,
+      text,
+      preferredLanguage: input.preferredLanguage,
+    });
+    const modelResult = await chatGateway.generate(pack);
+    if (modelResult.status === 'success' && modelResult.output) {
+      try {
+        const validated = validateFarmManagerChatOutput(modelResult.output, pack);
+        await aiFarmManagerRepository.recordPromptInvocation({
+          farmerId: input.farmerId,
+          farmId: farm.farm_id,
+          promptFamily: modelResult.promptFamily,
+          promptVersion: modelResult.promptVersion,
+          modelProvider: modelResult.provider,
+          modelName: modelResult.model,
+          inputTokenCount: modelResult.inputTokens,
+          outputTokenCount: modelResult.outputTokens,
+          estimatedCostUsd: modelResult.estimatedCostUsd,
+          latencyMs: modelResult.latencyMs,
+          status: 'success',
+          contextSourceCounts: chatContextSourceCounts(pack),
+          safetyFlags: validated.safety_flags,
+        });
+        return toReply(validated, modelResult.provider, modelResult.model, 'valid');
+      } catch (error) {
+        await aiFarmManagerRepository.recordPromptInvocation({
+          farmerId: input.farmerId,
+          farmId: farm.farm_id,
+          promptFamily: modelResult.promptFamily,
+          promptVersion: modelResult.promptVersion,
+          modelProvider: modelResult.provider,
+          modelName: modelResult.model,
+          inputTokenCount: modelResult.inputTokens,
+          outputTokenCount: modelResult.outputTokens,
+          estimatedCostUsd: modelResult.estimatedCostUsd,
+          latencyMs: modelResult.latencyMs,
+          status: 'validation_failed',
+          errorCode: error instanceof ChatValidationError
+            ? error.code
+            : 'chat_validation_failed',
+          contextSourceCounts: chatContextSourceCounts(pack),
+        });
+      }
+    } else {
+      await aiFarmManagerRepository.recordPromptInvocation({
+        farmerId: input.farmerId,
+        farmId: farm.farm_id,
+        promptFamily: CHAT_PROMPT_FAMILY,
+        promptVersion: CHAT_PROMPT_VERSION,
+        modelProvider: modelResult.provider,
+        modelName: modelResult.model,
+        estimatedCostUsd: modelResult.estimatedCostUsd,
+        latencyMs: modelResult.latencyMs,
+        status: modelResult.status === 'error' ? 'error' : 'fallback',
+        errorCode: modelResult.errorCode,
+        contextSourceCounts: chatContextSourceCounts(pack),
+      });
+    }
+    return deterministicReply(pack);
+  },
+};
+
+async function resolveFarm(farmerId: string, farmId: string): Promise<FarmerFarm> {
+  const farms = await authRepository.listFarms(farmerId);
+  const farm = farms.find((candidate) => candidate.farm_id === farmId);
+  if (!farm) throw new FarmManagerChatError('farm_not_found', 404);
+  return farm;
+}
+
+async function buildChatContextPack(input: {
+  farmerId: string;
+  farm: FarmerFarm;
+  text: string;
+  preferredLanguage?: string;
+}): Promise<FarmManagerChatContextPack> {
+  const [profile, recentCheckins, memories, recentPlans] = await Promise.all([
+    aiFarmManagerRepository.getActiveProfile({
+      farmerId: input.farmerId,
+      farmId: input.farm.farm_id,
+    }),
+    aiFarmManagerRepository.listCheckins({
+      farmerId: input.farmerId,
+      farmId: input.farm.farm_id,
+      limit: 2,
+    }),
+    aiFarmManagerRepository.listContextMemories({
+      farmerId: input.farmerId,
+      farmId: input.farm.farm_id,
+      limit: 5,
+    }),
+    aiFarmManagerRepository.listPlans({
+      farmerId: input.farmerId,
+      farmId: input.farm.farm_id,
+      limit: 1,
+    }),
+  ]);
+  return {
+    context_pack_version: 'farm-manager-chat-context-v1',
+    farmer: {
+      farmer_id: input.farmerId,
+      preferred_language: profile?.preferred_language ?? input.preferredLanguage ?? 'sn-en',
+    },
+    farm: {
+      farm_id: input.farm.farm_id,
+      name: input.farm.display_name,
+      site_id: input.farm.site_id,
+    },
+    ai_profile: profile ?? null,
+    recent_checkins: recentCheckins,
+    important_memories: memories,
+    recent_plans: recentPlans,
+    farmer_question: input.text,
+  };
+}
+
+function deterministicReply(pack: FarmManagerChatContextPack): FarmManagerChatReply {
+  const profile = pack.ai_profile;
+  const latestCheckin = pack.recent_checkins[0];
+  const latestPlan = pack.recent_plans[0];
+  const crop = latestCheckin?.crop || profile?.current_crop || profile?.main_crops[0] || 'your crop';
+  const issue = latestPlan?.main_issue
+    || profile?.primary_pain_point
+    || latestCheckin?.farmer_biggest_worry
+    || 'this week’s farm condition';
+  const action = latestPlan?.recommended_actions[0];
+  const answer = [
+    `For ${pack.farm.name}, I am looking at ${crop} and ${issue}.`,
+    latestCheckin
+      ? `Your latest check-in says soil is ${pretty(latestCheckin.soil_condition)}, plants are ${pretty(latestCheckin.plant_condition)}, and pest/disease signs are ${pretty(latestCheckin.pest_disease_signs)}.`
+      : 'I do not yet have a weekly check-in for this farm, so my advice is cautious.',
+    action
+      ? `Best next step: ${action.action}`
+      : 'Best next step: record a weekly check-in, then inspect soil moisture, plant colour, and pest signs before spending money.',
+  ].join('\n\n');
+  const safetyFlags = safetyFlagsFor(pack.farmer_question);
+  return {
+    answer,
+    shona_summary: `Tarisa ${crop}. Tanga nezvinhu zviri nyore uye nyora zvachinja.`,
+    recommended_next_step: action?.title || 'Complete a weekly farm check-in',
+    missing_information: latestCheckin ? [] : ['weekly check-in'],
+    evidence_used: [
+      ...(latestCheckin ? [{
+        type: 'checkin' as const,
+        id: latestCheckin.checkin_id,
+        summary: 'Latest weekly check-in.',
+      }] : []),
+      ...(latestPlan ? [{
+        type: 'previous_plan' as const,
+        id: latestPlan.plan_id,
+        summary: latestPlan.summary,
+      }] : []),
+      ...(profile ? [{
+        type: 'profile' as const,
+        id: profile.profile_id,
+        summary: profile.ai_manager_brief || 'AI Farm Manager profile.',
+      }] : []),
+    ],
+    confidence: latestCheckin ? 'medium' : 'low',
+    coordinator_review_required: safetyFlags.length > 0,
+    safety_flags: safetyFlags,
+    provider: 'edgechain',
+    model: 'deterministic-chat-pilot',
+    validation_status: 'fallback',
+  };
+}
+
+function toReply(
+  output: ValidatedFarmManagerChatOutput,
+  provider: string,
+  model: string,
+  validationStatus: 'valid' | 'fallback'
+): FarmManagerChatReply {
+  return {
+    ...output,
+    provider,
+    model,
+    validation_status: validationStatus,
+  };
+}
+
+function chatContextSourceCounts(pack: FarmManagerChatContextPack): Record<string, number> {
+  return {
+    profile: pack.ai_profile ? 1 : 0,
+    checkin: pack.recent_checkins.length,
+    memory: pack.important_memories.length,
+    previous_plan: pack.recent_plans.length,
+  };
+}
+
+function safetyFlagsFor(text: string): string[] {
+  const normalized = text.toLowerCase();
+  const flags: string[] = [];
+  if (/(pesticide|herbicide|fungicide|chemical|spray|dosage|dose)/.test(normalized)) {
+    flags.push('chemical_or_dosage_question');
+  }
+  if (/(buy|purchase|loan|borrow|expensive|fertili[sz]er)/.test(normalized)) {
+    flags.push('cost_or_input_purchase_question');
+  }
+  return flags;
+}
+
+function pretty(value: string | null | undefined): string {
+  return value ? value.replace(/_/g, ' ') : 'not recorded';
+}

--- a/apps/freedom-node/src/ai-farm-manager/chatValidation.ts
+++ b/apps/freedom-node/src/ai-farm-manager/chatValidation.ts
@@ -1,0 +1,122 @@
+import {
+  FarmManagerConfidence,
+  FarmManagerEvidenceUsed,
+} from './domain';
+import type { FarmManagerChatContextPack, FarmManagerChatReply } from './chatService';
+
+export type ValidatedFarmManagerChatOutput = Omit<
+  FarmManagerChatReply,
+  'provider' | 'model' | 'validation_status'
+>;
+
+const CONFIDENCE = ['low', 'medium', 'high'] as const;
+const EVIDENCE_TYPES = ['profile', 'memory', 'checkin', 'ndani_reading', 'previous_plan', 'playbook'] as const;
+const REVIEW_TERMS = [
+  'pesticide',
+  'herbicide',
+  'fungicide',
+  'chemical',
+  'spray',
+  'dosage',
+  'dose',
+  'fertilizer rate',
+  'sensor measured',
+  'hardware measured',
+];
+
+export class ChatValidationError extends Error {
+  constructor(public readonly code: string) {
+    super(code);
+  }
+}
+
+export function validateFarmManagerChatOutput(
+  value: unknown,
+  pack: FarmManagerChatContextPack
+): ValidatedFarmManagerChatOutput {
+  if (!isRecord(value)) throw new ChatValidationError('chat_output_not_object');
+  const answer = text(value.answer, 1600, 'missing_answer');
+  const recommendedNextStep = text(value.recommended_next_step, 300, 'missing_next_step');
+  const safetyFlags = Array.from(new Set([
+    ...stringList(value.safety_flags, 12, 80),
+    ...safetyFlagsForText(`${answer}\n${recommendedNextStep}`),
+  ]));
+  const confidence = enumValue(value.confidence, CONFIDENCE, 'invalid_confidence');
+  return {
+    answer,
+    shona_summary: optionalText(value.shona_summary, 500),
+    recommended_next_step: recommendedNextStep,
+    missing_information: stringList(value.missing_information, 8, 80),
+    evidence_used: evidenceList(value.evidence_used, pack),
+    confidence,
+    coordinator_review_required:
+      Boolean(value.coordinator_review_required)
+      || confidence === 'low'
+      || safetyFlags.length > 0,
+    safety_flags: safetyFlags,
+  };
+}
+
+function evidenceList(
+  value: unknown,
+  pack: FarmManagerChatContextPack
+): FarmManagerEvidenceUsed[] {
+  if (!Array.isArray(value)) return [];
+  const allowedIds = new Set([
+    pack.ai_profile?.profile_id,
+    ...pack.recent_checkins.map((item) => item.checkin_id),
+    ...pack.important_memories.map((item) => item.memory_id),
+    ...pack.recent_plans.map((item) => item.plan_id),
+  ].filter((item): item is string => Boolean(item)));
+  return value.slice(0, 8).flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const id = optionalText(item.id, 120);
+    if (!id || !allowedIds.has(id)) return [];
+    return [{
+      type: enumValue(item.type, EVIDENCE_TYPES, 'invalid_evidence_type'),
+      id,
+      summary: optionalText(item.summary, 300) ?? 'Evidence from context pack.',
+    }];
+  });
+}
+
+function safetyFlagsForText(textValue: string): string[] {
+  const normalized = textValue.toLowerCase();
+  return REVIEW_TERMS.filter((term) => normalized.includes(term)).map(
+    (term) => `review_term:${term.replace(/\s+/g, '_')}`
+  );
+}
+
+function enumValue<T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  code: string
+): T[number] {
+  const candidate = String(value ?? '').trim();
+  if (allowed.includes(candidate)) return candidate as T[number];
+  throw new ChatValidationError(code);
+}
+
+function text(value: unknown, maxLength: number, code: string): string {
+  const result = optionalText(value, maxLength);
+  if (!result) throw new ChatValidationError(code);
+  return result;
+}
+
+function optionalText(value: unknown, maxLength: number): string | null {
+  if (value === undefined || value === null) return null;
+  const result = String(value).trim();
+  return result ? result.slice(0, maxLength) : null;
+}
+
+function stringList(value: unknown, maxItems: number, maxLength: number): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    const result = optionalText(item, maxLength);
+    return result ? [result] : [];
+  }).slice(0, maxItems);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/freedom-node/src/routes/aiFarmManager.ts
+++ b/apps/freedom-node/src/routes/aiFarmManager.ts
@@ -4,6 +4,10 @@ import {
   AiFarmManagerCheckinError,
   aiFarmManagerCheckinService,
 } from '../ai-farm-manager/checkinService';
+import {
+  FarmManagerChatError,
+  farmManagerChatService,
+} from '../ai-farm-manager/chatService';
 import { aiFarmManagerWeeklyPlanService } from '../ai-farm-manager/weeklyPlanService';
 
 const router = Router();
@@ -56,8 +60,25 @@ router.get('/plans', async (req: FarmerRequest, res) => {
   }
 });
 
+router.post('/chat', async (req: FarmerRequest, res) => {
+  try {
+    const reply = await farmManagerChatService.reply({
+      farmerId: req.farmer!.farmer_id,
+      farmId: String(req.body.farm_id ?? ''),
+      text: String(req.body.text ?? ''),
+      preferredLanguage: req.farmer!.preferred_language,
+    });
+    return res.status(201).json({ success: true, reply });
+  } catch (error) {
+    return handleError(error, res);
+  }
+});
+
 function handleError(error: unknown, res: any) {
   if (error instanceof AiFarmManagerCheckinError) {
+    return res.status(error.status).json({ error: error.code });
+  }
+  if (error instanceof FarmManagerChatError) {
     return res.status(error.status).json({ error: error.code });
   }
   return res.status(500).json({ error: 'ai_farm_manager_request_failed' });

--- a/apps/web/src/agent/api.ts
+++ b/apps/web/src/agent/api.ts
@@ -1,6 +1,7 @@
 import type {
   AgentMessageResponse,
   AgentConversationResponse,
+  FarmManagerChatResponse,
   PilotSession,
   VirtualNdaniDevice,
   VirtualNdaniEvent,
@@ -89,6 +90,21 @@ export async function sendAgentMessage(input: {
   });
   if (!response.ok) throw await toApiError(response);
   return response.json() as Promise<AgentMessageResponse>;
+}
+
+export async function sendFarmManagerChatMessage(input: {
+  farmId: string;
+  text: string;
+}): Promise<FarmManagerChatResponse> {
+  const response = await request('/api/v1/ai-farm-manager/chat', {
+    method: 'POST',
+    body: JSON.stringify({
+      farm_id: input.farmId,
+      text: input.text,
+    }),
+  });
+  if (!response.ok) throw await toApiError(response);
+  return response.json() as Promise<FarmManagerChatResponse>;
 }
 
 export async function loadLatestAgentConversation(

--- a/apps/web/src/agent/types.ts
+++ b/apps/web/src/agent/types.ts
@@ -282,6 +282,29 @@ export interface AgentMessageResponse {
   };
 }
 
+export interface FarmManagerChatReply {
+  answer: string;
+  shona_summary: string | null;
+  recommended_next_step: string | null;
+  missing_information: string[];
+  evidence_used: Array<{
+    type: 'profile' | 'memory' | 'checkin' | 'ndani_reading' | 'previous_plan' | 'playbook';
+    id: string;
+    summary: string;
+  }>;
+  confidence: 'low' | 'medium' | 'high';
+  coordinator_review_required: boolean;
+  safety_flags: string[];
+  provider: string;
+  model: string;
+  validation_status: 'valid' | 'fallback';
+}
+
+export interface FarmManagerChatResponse {
+  success: true;
+  reply: FarmManagerChatReply;
+}
+
 export interface AgentConversationResponse {
   success: true;
   conversation: AgentMessageResponse['conversation'];

--- a/apps/web/src/screens/FarmAssistant.tsx
+++ b/apps/web/src/screens/FarmAssistant.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import {
   AgentApiError,
   loadLatestAgentConversation,
-  sendAgentMessage,
+  sendFarmManagerChatMessage,
 } from '../agent/api';
 import type {
   AgentChatMessage,
@@ -23,12 +23,11 @@ export function FarmAssistant({
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [submittedDeviceCode, setSubmittedDeviceCode] = useState<string | null>(null);
   const [messages, setMessages] = useState<AgentChatMessage[]>([
     {
       id: 'welcome',
       sender: 'agent',
-      text: `Mauya, ${session.farmer.display_name}. Tell me what you noticed on your farm today. You may use Shona or English.`,
+      text: `Mauya, ${session.farmer.display_name}. Ask me about your farm plan, crop, water, pests, or what to do next. I will use your EdgeChain farm memory.`,
       createdAt: new Date(),
     },
   ]);
@@ -78,20 +77,26 @@ export function FarmAssistant({
     setError(null);
 
     try {
-      const result = await sendAgentMessage({
+      const result = await sendFarmManagerChatMessage({
         farmId,
         text,
-        externalMessageId: clientMessageId,
       });
+      const reply = [
+        result.reply.answer,
+        result.reply.shona_summary ? `\nShona: ${result.reply.shona_summary}` : '',
+        result.reply.recommended_next_step
+          ? `\nNext step: ${result.reply.recommended_next_step}`
+          : '',
+        result.reply.coordinator_review_required
+          ? '\nCoordinator review recommended before taking risky or costly action.'
+          : '',
+      ].filter(Boolean).join('\n');
       setMessages((current) => [...current, {
         id: `${clientMessageId}-reply`,
         sender: 'agent',
-        text: result.reply,
+        text: reply,
         createdAt: new Date(),
       }]);
-      if (result.virtual_ndani) {
-        setSubmittedDeviceCode(result.virtual_ndani.device_code);
-      }
     } catch (sendError) {
       setError(
         sendError instanceof AgentApiError
@@ -130,7 +135,7 @@ export function FarmAssistant({
           <div>
             <PilotBrand compact />
             <p className="text-xs font-bold uppercase tracking-[0.2em] text-blue-700">
-              <span className="mt-4 block">Virtual Ndani Kit Farm Assistant</span>
+              <span className="mt-4 block">AI Farm Manager</span>
             </p>
             <h1 className="mt-1 text-3xl font-black">{session.farmer.display_name}</h1>
             <p className="text-sm text-gray-600">
@@ -168,22 +173,8 @@ export function FarmAssistant({
 
         <section className="overflow-hidden border-2 border-black bg-white">
           <div className="border-b-2 border-black bg-blue-700 px-5 py-3 text-sm font-bold text-white">
-            You observe · the assistant structures · Virtual Ndani Kit records
+            Your profile · weekly check-ins · AI plans · farm memory
           </div>
-          {submittedDeviceCode && (
-            <div className="border-b-2 border-black bg-[#dff3d8] px-5 py-4">
-              <p className="font-black">
-                Reading added to {submittedDeviceCode}
-              </p>
-              <button
-                type="button"
-                onClick={() => navigate('/virtual-ndani')}
-                className="mt-2 font-black text-[#183c28] underline"
-              >
-                View the reading on Virtual Ndani Kit
-              </button>
-            </div>
-          )}
           <div
             className="h-[52vh] min-h-[360px] space-y-4 overflow-y-auto bg-[#fbfbf7] p-4 md:p-6"
             aria-live="polite"
@@ -228,7 +219,7 @@ export function FarmAssistant({
                 onChange={(event) => setInput(event.target.value)}
                 rows={2}
                 maxLength={2000}
-                placeholder="What did you notice on the farm?"
+                placeholder="Ask about your farm plan, crop, water, pests, or next step..."
                 className="min-h-16 flex-1 resize-none border-2 border-black px-4 py-3 text-lg"
               />
               <button
@@ -240,7 +231,7 @@ export function FarmAssistant({
               </button>
             </div>
             <p className="mt-2 text-xs text-gray-500">
-              Do not send wallet passwords, recovery phrases, or personal secrets.
+              Do not send wallet passwords, recovery phrases, or personal secrets. Use the Weekly Farm Check-in screen for structured weekly records.
             </p>
           </form>
         </section>


### PR DESCRIPTION
Added memory-based AI Farm Manager chat backend:context from AI profile
recent check-ins
recent AI plans
durable memories
farmer/farm identity

Added /api/v1/ai-farm-manager/chat
Added Gemini-ready chat prompt/gateway/validation.
Keeps deterministic fallback if Gemini is off or unavailable.
Updated /farm-assistant to behave as the personalized AI Farm Manager chat.
Kept the older observation pipeline intact under /api/v1/agent/messages.
Documented AI_FARM_MANAGER_CHAT_MAX_OUTPUT_TOKENS.
Validation passed:
Backend TypeScript
Backend build
Frontend ESLint
Frontend build
git diff --check
To test:
Log in as a farmer.
Create/update the farmer’s AI profile in coordinator admin if needed.
Submit a weekly check-in.
Go to /farm-assistant.
Ask: “What should I do on my farm this week?”
The reply should reference the farmer’s farm memory/check-ins/plans, with deterministic fallback unless Gemini is enabled.