### PR TITLE
Add farmer timeline and AI report

### DIFF
--- a/apps/freedom-node/src/ai-farm-manager/timelineReportService.ts
+++ b/apps/freedom-node/src/ai-farm-manager/timelineReportService.ts
@@ -1,0 +1,341 @@
+import { authRepository, FarmerFarm } from '../auth/authRepository';
+import { virtualNdaniService } from '../virtual-ndani/service';
+import {
+  AiFarmPlan,
+  AiRecommendationOutcome,
+  FarmerAiProfile,
+  WeeklyFarmCheckin,
+} from './domain';
+import { aiFarmManagerRepository } from './repository';
+
+export type FarmerTimelineEventType =
+  | 'profile'
+  | 'checkin'
+  | 'plan'
+  | 'outcome'
+  | 'ndani_kit';
+
+export interface FarmerTimelineEvent {
+  event_id: string;
+  event_type: FarmerTimelineEventType;
+  occurred_at: number;
+  title: string;
+  summary: string;
+  risk_level: 'low' | 'medium' | 'high' | null;
+  source_id: string;
+}
+
+export interface FarmerAiReport {
+  report_version: 'farmer-ai-report-v1';
+  generated_at: number;
+  farmer_id: string;
+  farm: {
+    farm_id: string;
+    name: string;
+    site_id: string;
+  };
+  profile: {
+    current_crop: string | null;
+    current_crop_stage: string | null;
+    main_crops: string[];
+    primary_goal: string | null;
+    primary_pain_point: string | null;
+    water_access: string | null;
+    irrigation_method: string | null;
+    soil_type: string | null;
+    ai_manager_brief: string | null;
+  } | null;
+  summary: {
+    checkins: number;
+    plans: number;
+    outcomes: number;
+    high_risk_weeks: number;
+    latest_risk_level: 'low' | 'medium' | 'high' | null;
+    coordinator_reviews_recommended: number;
+    virtual_ndani_devices: number;
+  };
+  crop_journey: string[];
+  weekly_observation_summary: string[];
+  advice_summary: string[];
+  follow_up_questions: string[];
+  lessons_learned: string[];
+  next_season_recommendations: string[];
+  physical_ndani_kit_readiness: string;
+  privacy_and_control_statement: string;
+}
+
+export class FarmerTimelineReportError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number
+  ) {
+    super(code);
+  }
+}
+
+export const farmerTimelineReportService = {
+  async timeline(input: {
+    farmerId: string;
+    farmId?: unknown;
+  }): Promise<FarmerTimelineEvent[]> {
+    const context = await loadContext(input.farmerId, input.farmId);
+    return buildTimeline(context);
+  },
+
+  async report(input: {
+    farmerId: string;
+    farmId?: unknown;
+  }): Promise<FarmerAiReport> {
+    const context = await loadContext(input.farmerId, input.farmId);
+    return buildReport(context);
+  },
+};
+
+async function loadContext(farmerId: string, requestedFarmId: unknown) {
+  const farm = await resolveFarm(farmerId, requestedFarmId);
+  const [profile, checkins, plans, outcomes, devices] = await Promise.all([
+    aiFarmManagerRepository.getActiveProfile({
+      farmerId,
+      farmId: farm.farm_id,
+    }),
+    aiFarmManagerRepository.listCheckins({
+      farmerId,
+      farmId: farm.farm_id,
+      limit: 52,
+    }),
+    aiFarmManagerRepository.listPlans({
+      farmerId,
+      farmId: farm.farm_id,
+      limit: 52,
+    }),
+    aiFarmManagerRepository.listOutcomesForFarmer({
+      farmerId,
+      limit: 52,
+    }),
+    virtualNdaniService.list(farmerId),
+  ]);
+  return {
+    farmerId,
+    farm,
+    profile: profile ?? null,
+    checkins,
+    plans,
+    outcomes,
+    devices: devices.filter((device) => device.farm_id === farm.farm_id),
+  };
+}
+
+async function resolveFarm(farmerId: string, requestedFarmId: unknown): Promise<FarmerFarm> {
+  const farms = await authRepository.listFarms(farmerId);
+  if (farms.length === 0) {
+    throw new FarmerTimelineReportError('farm_not_found', 404);
+  }
+  const farmId = typeof requestedFarmId === 'string' ? requestedFarmId.trim() : '';
+  if (!farmId) return farms[0];
+  const farm = farms.find((candidate) => candidate.farm_id === farmId);
+  if (!farm) throw new FarmerTimelineReportError('farm_not_found', 404);
+  return farm;
+}
+
+function buildTimeline(context: {
+  farm: FarmerFarm;
+  profile: FarmerAiProfile | null;
+  checkins: WeeklyFarmCheckin[];
+  plans: AiFarmPlan[];
+  outcomes: AiRecommendationOutcome[];
+  devices: any[];
+}): FarmerTimelineEvent[] {
+  const events: FarmerTimelineEvent[] = [];
+  if (context.profile) {
+    events.push({
+      event_id: `profile-${context.profile.profile_id}`,
+      event_type: 'profile',
+      occurred_at: context.profile.updated_at,
+      title: 'AI Farm Manager profile updated',
+      summary: context.profile.ai_manager_brief
+        || context.profile.farm_story_summary
+        || 'Farmer profile captured for personalization.',
+      risk_level: null,
+      source_id: context.profile.profile_id,
+    });
+  }
+  for (const checkin of context.checkins) {
+    events.push({
+      event_id: `checkin-${checkin.checkin_id}`,
+      event_type: 'checkin',
+      occurred_at: checkin.created_at,
+      title: `Weekly check-in: ${checkin.crop || context.profile?.current_crop || 'crop not named'}`,
+      summary: `Soil ${pretty(checkin.soil_condition)}, plants ${pretty(checkin.plant_condition)}, pests ${pretty(checkin.pest_disease_signs)}. ${checkin.farmer_biggest_worry || ''}`.trim(),
+      risk_level: checkin.risk_level,
+      source_id: checkin.checkin_id,
+    });
+  }
+  for (const plan of context.plans) {
+    events.push({
+      event_id: `plan-${plan.plan_id}`,
+      event_type: 'plan',
+      occurred_at: plan.created_at,
+      title: `AI plan: ${plan.main_issue || 'weekly farm guidance'}`,
+      summary: plan.summary,
+      risk_level: plan.risk_level,
+      source_id: plan.plan_id,
+    });
+  }
+  for (const outcome of context.outcomes) {
+    events.push({
+      event_id: `outcome-${outcome.outcome_id}`,
+      event_type: 'outcome',
+      occurred_at: outcome.updated_at,
+      title: 'Recommendation follow-up recorded',
+      summary: outcome.outcome_observed
+        || outcome.farmer_feedback
+        || 'Recommendation outcome captured.',
+      risk_level: null,
+      source_id: outcome.outcome_id,
+    });
+  }
+  for (const device of context.devices) {
+    events.push({
+      event_id: `ndani-${device.virtual_device_id}`,
+      event_type: 'ndani_kit',
+      occurred_at: device.latest_reading?.recorded_at || device.due_at || Math.floor(Date.now() / 1000),
+      title: `${device.device_code} linked to farm record`,
+      summary: `${device.mode === 'physical_bound' ? 'Physical Ndani Kit connected' : 'Human-assisted Virtual Ndani Kit'} with ${device.operations.completed_cycles} completed checks.`,
+      risk_level: null,
+      source_id: device.virtual_device_id,
+    });
+  }
+  return events.sort((a, b) => b.occurred_at - a.occurred_at);
+}
+
+function buildReport(context: {
+  farmerId: string;
+  farm: FarmerFarm;
+  profile: FarmerAiProfile | null;
+  checkins: WeeklyFarmCheckin[];
+  plans: AiFarmPlan[];
+  outcomes: AiRecommendationOutcome[];
+  devices: any[];
+}): FarmerAiReport {
+  const latestCheckin = context.checkins[0];
+  const highRiskWeeks = context.checkins.filter((item) => item.risk_level === 'high').length;
+  const reviews = context.plans.filter((plan) => plan.coordinator_review_required).length;
+  const crops = unique([
+    ...context.checkins.map((item) => item.crop).filter(Boolean),
+    context.profile?.current_crop,
+    ...(context.profile?.main_crops ?? []),
+  ]);
+  return {
+    report_version: 'farmer-ai-report-v1',
+    generated_at: Math.floor(Date.now() / 1000),
+    farmer_id: context.farmerId,
+    farm: {
+      farm_id: context.farm.farm_id,
+      name: context.farm.display_name,
+      site_id: context.farm.site_id,
+    },
+    profile: context.profile
+      ? {
+          current_crop: context.profile.current_crop,
+          current_crop_stage: context.profile.current_crop_stage,
+          main_crops: context.profile.main_crops,
+          primary_goal: context.profile.primary_goal,
+          primary_pain_point: context.profile.primary_pain_point,
+          water_access: context.profile.water_access,
+          irrigation_method: context.profile.irrigation_method,
+          soil_type: context.profile.soil_type,
+          ai_manager_brief: context.profile.ai_manager_brief,
+        }
+      : null,
+    summary: {
+      checkins: context.checkins.length,
+      plans: context.plans.length,
+      outcomes: context.outcomes.length,
+      high_risk_weeks: highRiskWeeks,
+      latest_risk_level: latestCheckin?.risk_level ?? null,
+      coordinator_reviews_recommended: reviews,
+      virtual_ndani_devices: context.devices.length,
+    },
+    crop_journey: crops.length > 0
+      ? crops.map((crop) => `${crop} appears in this farm’s AI record.`)
+      : ['No crop journey has been recorded yet.'],
+    weekly_observation_summary: context.checkins.slice(0, 8).map((checkin) => (
+      `${formatDate(checkin.week_start)}: ${checkin.crop || 'crop not named'} — soil ${pretty(checkin.soil_condition)}, plants ${pretty(checkin.plant_condition)}, pests ${pretty(checkin.pest_disease_signs)}.`
+    )),
+    advice_summary: context.plans.slice(0, 8).map((plan) => (
+      `${formatDate(plan.created_at)}: ${plan.main_issue || 'weekly guidance'} — ${plan.recommended_actions.length} recommended action(s).`
+    )),
+    follow_up_questions: context.plans
+      .map((plan) => plan.follow_up_question)
+      .filter((question): question is string => Boolean(question))
+      .slice(0, 8),
+    lessons_learned: lessonsLearned(context.checkins, context.plans),
+    next_season_recommendations: nextSeasonRecommendations(context.profile, context.checkins),
+    physical_ndani_kit_readiness: physicalReadiness(context.devices, context.checkins),
+    privacy_and_control_statement:
+      'This report is built from this farmer’s EdgeChain records. In production, the farmer should control access to farm data, Ndani Kit identity, AI memory, and any participation in federated learning or research.',
+  };
+}
+
+function lessonsLearned(checkins: WeeklyFarmCheckin[], plans: AiFarmPlan[]): string[] {
+  const lessons: string[] = [];
+  if (checkins.some((item) => item.soil_condition === 'dry' || item.soil_condition === 'very_dry')) {
+    lessons.push('Water timing and soil moisture should remain a weekly focus.');
+  }
+  if (checkins.some((item) => item.pest_disease_signs === 'some' || item.pest_disease_signs === 'severe')) {
+    lessons.push('Pest and disease scouting should be recorded early, before advice becomes risky or expensive.');
+  }
+  if (plans.some((plan) => plan.coordinator_review_required)) {
+    lessons.push('Some weeks needed coordinator review, which is a safety feature rather than a failure.');
+  }
+  if (lessons.length === 0) {
+    lessons.push('The farm record is still young; consistent weekly check-ins will make the AI manager more useful.');
+  }
+  return lessons;
+}
+
+function nextSeasonRecommendations(
+  profile: FarmerAiProfile | null,
+  checkins: WeeklyFarmCheckin[]
+): string[] {
+  const recommendations = [
+    'Continue weekly check-ins so the AI Farm Manager can compare conditions over time.',
+    'Use Ndani Kit records to separate human observations from physical sensor measurements.',
+  ];
+  if (profile?.water_access || checkins.some((item) => item.soil_condition === 'dry')) {
+    recommendations.push('Plan water-sensitive crop stages in advance and record irrigation constraints clearly.');
+  }
+  if (checkins.some((item) => item.pest_disease_signs !== 'none')) {
+    recommendations.push('Keep a simple pest scouting habit: inspect several plants and record where symptoms appear.');
+  }
+  return recommendations;
+}
+
+function physicalReadiness(devices: any[], checkins: WeeklyFarmCheckin[]): string {
+  const completedCycles = devices.reduce(
+    (sum, device) => sum + Number(device.operations?.completed_cycles ?? 0),
+    0
+  );
+  if (devices.some((device) => device.mode === 'physical_bound')) {
+    return 'This farm already has a physical Ndani Kit binding recorded; manual history remains valuable context.';
+  }
+  if (checkins.length >= 3 || completedCycles >= 3) {
+    return 'This farm has enough manual engagement to justify prioritizing a physical Ndani Kit when hardware becomes available.';
+  }
+  return 'This farm should build more weekly history before physical Ndani Kit prioritization is assessed.';
+}
+
+function pretty(value: string | null | undefined): string {
+  return value ? value.replace(/_/g, ' ') : 'not recorded';
+}
+
+function unique(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.flatMap((value) => {
+    const text = value?.trim();
+    return text ? [text] : [];
+  })));
+}
+
+function formatDate(epoch: number): string {
+  return new Date(epoch * 1000).toISOString().slice(0, 10);
+}

--- a/apps/freedom-node/src/routes/aiFarmManager.ts
+++ b/apps/freedom-node/src/routes/aiFarmManager.ts
@@ -8,6 +8,10 @@ import {
   FarmManagerChatError,
   farmManagerChatService,
 } from '../ai-farm-manager/chatService';
+import {
+  FarmerTimelineReportError,
+  farmerTimelineReportService,
+} from '../ai-farm-manager/timelineReportService';
 import { aiFarmManagerWeeklyPlanService } from '../ai-farm-manager/weeklyPlanService';
 
 const router = Router();
@@ -74,11 +78,38 @@ router.post('/chat', async (req: FarmerRequest, res) => {
   }
 });
 
+router.get('/timeline', async (req: FarmerRequest, res) => {
+  try {
+    const events = await farmerTimelineReportService.timeline({
+      farmerId: req.farmer!.farmer_id,
+      farmId: req.query.farm_id,
+    });
+    return res.json({ success: true, events });
+  } catch (error) {
+    return handleError(error, res);
+  }
+});
+
+router.get('/report', async (req: FarmerRequest, res) => {
+  try {
+    const report = await farmerTimelineReportService.report({
+      farmerId: req.farmer!.farmer_id,
+      farmId: req.query.farm_id,
+    });
+    return res.json({ success: true, report });
+  } catch (error) {
+    return handleError(error, res);
+  }
+});
+
 function handleError(error: unknown, res: any) {
   if (error instanceof AiFarmManagerCheckinError) {
     return res.status(error.status).json({ error: error.code });
   }
   if (error instanceof FarmManagerChatError) {
+    return res.status(error.status).json({ error: error.code });
+  }
+  if (error instanceof FarmerTimelineReportError) {
     return res.status(error.status).json({ error: error.code });
   }
   return res.status(500).json({ error: 'ai_farm_manager_request_failed' });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@ import { PredictionsRoute } from "./routes/PredictionsRoute";
 import { PilotLoginRoute } from "./routes/PilotLoginRoute";
 import { FarmAssistantRoute } from "./routes/FarmAssistantRoute";
 import { FarmCheckInRoute } from "./routes/FarmCheckInRoute";
+import { FarmTimelineRoute } from "./routes/FarmTimelineRoute";
 import { VirtualNdaniRoute } from "./routes/VirtualNdaniRoute";
 import { VirtualNdaniReadingRoute } from "./routes/VirtualNdaniReadingRoute";
 import { CoordinatorRoute } from "./routes/CoordinatorRoute";
@@ -46,6 +47,7 @@ export default function EdgeChainApp() {
             <Route path="/virtual-ndani/reading" element={<VirtualNdaniReadingRoute />} />
             <Route path="/virtual-ndani/demo" element={<PhysicalNdaniDemoRoute />} />
             <Route path="/farm-check-in" element={<FarmCheckInRoute />} />
+            <Route path="/farm-timeline" element={<FarmTimelineRoute />} />
             <Route path="/farm-assistant" element={<FarmAssistantRoute />} />
             <Route path="/coordinator" element={<CoordinatorRoute />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/apps/web/src/agent/api.ts
+++ b/apps/web/src/agent/api.ts
@@ -14,6 +14,8 @@ import type {
   CoordinatorReadingReview,
   FarmerAiProfile,
   AiFarmPlan,
+  FarmerAiReport,
+  FarmerTimelineEvent,
   WeeklyFarmCheckin,
   WeeklyFarmCheckinDraft,
   PilotOperationsMetrics,
@@ -401,6 +403,36 @@ export async function loadAiFarmPlans(): Promise<AiFarmPlan[]> {
     plans: AiFarmPlan[];
   };
   return body.plans;
+}
+
+export async function loadFarmerTimeline(
+  farmId: string
+): Promise<FarmerTimelineEvent[]> {
+  const response = await request(
+    `/api/v1/ai-farm-manager/timeline?farm_id=${encodeURIComponent(farmId)}`,
+    { method: 'GET' }
+  );
+  if (!response.ok) throw await toApiError(response);
+  const body = await response.json() as {
+    success: true;
+    events: FarmerTimelineEvent[];
+  };
+  return body.events;
+}
+
+export async function loadFarmerAiReport(
+  farmId: string
+): Promise<FarmerAiReport> {
+  const response = await request(
+    `/api/v1/ai-farm-manager/report?farm_id=${encodeURIComponent(farmId)}`,
+    { method: 'GET' }
+  );
+  if (!response.ok) throw await toApiError(response);
+  const body = await response.json() as {
+    success: true;
+    report: FarmerAiReport;
+  };
+  return body.report;
 }
 
 export async function saveWeeklyFarmCheckin(

--- a/apps/web/src/agent/types.ts
+++ b/apps/web/src/agent/types.ts
@@ -177,6 +177,55 @@ export interface AiFarmPlan {
   created_at: number;
 }
 
+export interface FarmerTimelineEvent {
+  event_id: string;
+  event_type: 'profile' | 'checkin' | 'plan' | 'outcome' | 'ndani_kit';
+  occurred_at: number;
+  title: string;
+  summary: string;
+  risk_level: 'low' | 'medium' | 'high' | null;
+  source_id: string;
+}
+
+export interface FarmerAiReport {
+  report_version: 'farmer-ai-report-v1';
+  generated_at: number;
+  farmer_id: string;
+  farm: {
+    farm_id: string;
+    name: string;
+    site_id: string;
+  };
+  profile: {
+    current_crop: string | null;
+    current_crop_stage: string | null;
+    main_crops: string[];
+    primary_goal: string | null;
+    primary_pain_point: string | null;
+    water_access: string | null;
+    irrigation_method: string | null;
+    soil_type: string | null;
+    ai_manager_brief: string | null;
+  } | null;
+  summary: {
+    checkins: number;
+    plans: number;
+    outcomes: number;
+    high_risk_weeks: number;
+    latest_risk_level: 'low' | 'medium' | 'high' | null;
+    coordinator_reviews_recommended: number;
+    virtual_ndani_devices: number;
+  };
+  crop_journey: string[];
+  weekly_observation_summary: string[];
+  advice_summary: string[];
+  follow_up_questions: string[];
+  lessons_learned: string[];
+  next_season_recommendations: string[];
+  physical_ndani_kit_readiness: string;
+  privacy_and_control_statement: string;
+}
+
 export interface PilotOperationsMetrics {
   devices: number;
   total_cycles: number;

--- a/apps/web/src/routes/FarmTimelineRoute.tsx
+++ b/apps/web/src/routes/FarmTimelineRoute.tsx
@@ -1,0 +1,31 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAgentSession } from '../agent/agentSessionContext';
+import { VIRTUAL_NDANI_ENABLED } from '../agent/api';
+import { FarmTimelineReport } from '../screens/FarmTimelineReport';
+import { PilotLoading } from './PilotLoginRoute';
+
+export function FarmTimelineRoute() {
+  const agent = useAgentSession();
+  const location = useLocation();
+
+  if (!VIRTUAL_NDANI_ENABLED) {
+    return <Navigate to="/farm-assistant" replace />;
+  }
+  if (agent.loading) {
+    return <PilotLoading label="Opening your farm timeline…" />;
+  }
+  if (!agent.session) {
+    return (
+      <Navigate
+        to="/pilot-login"
+        state={{ from: location.pathname }}
+        replace
+      />
+    );
+  }
+  if (agent.session.farmer.system_role === 'coordinator') {
+    return <Navigate to="/coordinator" replace />;
+  }
+
+  return <FarmTimelineReport session={agent.session} onLogout={agent.logout} />;
+}

--- a/apps/web/src/screens/FarmTimelineReport.tsx
+++ b/apps/web/src/screens/FarmTimelineReport.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  loadFarmerAiReport,
+  loadFarmerTimeline,
+} from '../agent/api';
+import { PilotBrand } from '../agent/PilotBrand';
+import type {
+  FarmerAiReport,
+  FarmerTimelineEvent,
+  PilotSession,
+} from '../agent/types';
+
+export function FarmTimelineReport({
+  session,
+  onLogout,
+}: {
+  session: PilotSession;
+  onLogout: () => Promise<void>;
+}) {
+  const navigate = useNavigate();
+  const [farmId, setFarmId] = useState(session.farms[0]?.farm_id || '');
+  const [timeline, setTimeline] = useState<FarmerTimelineEvent[]>([]);
+  const [report, setReport] = useState<FarmerAiReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedFarm = useMemo(
+    () => session.farms.find((farm) => farm.farm_id === farmId),
+    [session.farms, farmId]
+  );
+
+  useEffect(() => {
+    if (!farmId) return;
+    let active = true;
+    setLoading(true);
+    setError(null);
+    void Promise.all([
+      loadFarmerTimeline(farmId),
+      loadFarmerAiReport(farmId),
+    ])
+      .then(([events, farmReport]) => {
+        if (!active) return;
+        setTimeline(events);
+        setReport(farmReport);
+      })
+      .catch(() => {
+        if (active) setError('EdgeChain could not load the farm timeline and report.');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [farmId]);
+
+  if (session.farms.length === 0) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#f4f1e8] p-6">
+        <section className="max-w-lg border-2 border-black bg-white p-8 shadow-[8px_8px_0_#000]">
+          <h1 className="text-3xl font-black">No farm assigned</h1>
+          <p className="mt-4 text-gray-700">
+            Ask the pilot coordinator to assign a farm to your farmer profile.
+          </p>
+          <button
+            onClick={() => void onLogout().then(() => navigate('/pilot-login'))}
+            className="mt-7 bg-black px-5 py-3 font-bold text-white"
+          >
+            Sign out
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-[#f4f1e8] px-4 pb-16 pt-20 text-[#171713] sm:px-6">
+      <div className="mx-auto max-w-6xl">
+        <header className="grid gap-5 border-b-2 border-black pb-7 md:grid-cols-[1fr_auto] md:items-end">
+          <div>
+            <PilotBrand compact />
+            <p className="mt-5 text-sm font-black uppercase tracking-[0.2em] text-[#27653a]">
+              Farm timeline and report
+            </p>
+            <h1 className="mt-2 text-4xl font-black leading-none sm:text-5xl">
+              Your farm intelligence record
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg text-gray-700">
+              EdgeChain remembers your check-ins, AI plans, follow-ups and Ndani Kit activity so your farm record becomes more useful over time.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={() => navigate('/virtual-ndani')}
+              className="border-2 border-black bg-[#f1d34f] px-5 py-3 font-black"
+            >
+              My Virtual Ndani Kit
+            </button>
+            <button
+              type="button"
+              onClick={() => void onLogout().then(() => navigate('/pilot-login'))}
+              className="border-2 border-black bg-white px-5 py-3 font-black hover:bg-black hover:text-white"
+            >
+              Sign out
+            </button>
+          </div>
+        </header>
+
+        <section className="mt-6 flex flex-wrap items-center gap-3">
+          <label className="font-black">
+            Farm
+            <select
+              value={farmId}
+              onChange={(event) => setFarmId(event.target.value)}
+              className="ml-3 border-2 border-black bg-white px-3 py-2 font-bold"
+            >
+              {session.farms.map((farm) => (
+                <option key={farm.farm_id} value={farm.farm_id}>
+                  {farm.display_name} · {farm.site_id}
+                </option>
+              ))}
+            </select>
+          </label>
+          {selectedFarm && (
+            <span className="border border-black bg-white px-3 py-2 text-sm font-bold">
+              {selectedFarm.display_name} · {selectedFarm.site_id}
+            </span>
+          )}
+        </section>
+
+        {error && (
+          <p role="alert" className="mt-6 border-l-4 border-red-700 bg-red-50 p-4 font-bold text-red-800">
+            {error}
+          </p>
+        )}
+
+        {loading ? (
+          <p className="mt-8 text-lg font-black">Loading your farm record…</p>
+        ) : (
+          <div className="mt-7 grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
+            <section className="space-y-5">
+              {report && <ReportSummary report={report} />}
+              {report && <FarmerReport report={report} />}
+            </section>
+            <section className="border-2 border-black bg-white p-5 shadow-[8px_8px_0_#000]">
+              <p className="text-xs font-black uppercase tracking-[0.18em] text-[#27653a]">
+                Timeline
+              </p>
+              <h2 className="mt-1 text-3xl font-black">What EdgeChain remembers</h2>
+              {timeline.length === 0 ? (
+                <p className="mt-4 text-gray-600">
+                  No farm timeline events yet. Start with a weekly check-in.
+                </p>
+              ) : (
+                <ol className="mt-6 space-y-4">
+                  {timeline.map((event) => (
+                    <li
+                      key={event.event_id}
+                      className="grid grid-cols-[16px_1fr] gap-3 border-b border-gray-200 pb-4"
+                    >
+                      <span className={`mt-1.5 h-4 w-4 rounded-full ${eventDot(event.event_type)}`} />
+                      <article>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="font-black">{event.title}</p>
+                          <span className="border border-black px-2 py-0.5 text-[10px] font-black uppercase">
+                            {event.event_type.replace(/_/g, ' ')}
+                          </span>
+                          {event.risk_level && (
+                            <span className="bg-[#f1d34f] px-2 py-0.5 text-[10px] font-black uppercase">
+                              {event.risk_level} risk
+                            </span>
+                          )}
+                        </div>
+                        <p className="mt-1 text-xs text-gray-500">{formatDateTime(event.occurred_at)}</p>
+                        <p className="mt-2 text-sm leading-relaxed text-gray-700">{event.summary}</p>
+                      </article>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </section>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function ReportSummary({ report }: { report: FarmerAiReport }) {
+  return (
+    <section className="border-2 border-black bg-[#183c28] p-5 text-white shadow-[8px_8px_0_#000]">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-[#cbe7ba]">
+        Pilot report
+      </p>
+      <h2 className="mt-1 text-3xl font-black">{report.farm.name}</h2>
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        <Metric label="Check-ins" value={String(report.summary.checkins)} />
+        <Metric label="AI plans" value={String(report.summary.plans)} />
+        <Metric label="High-risk weeks" value={String(report.summary.high_risk_weeks)} />
+        <Metric label="Ndani Kits" value={String(report.summary.virtual_ndani_devices)} />
+      </div>
+      <p className="mt-5 border-l-4 border-[#cbe7ba] bg-white/10 p-3 text-sm">
+        {report.physical_ndani_kit_readiness}
+      </p>
+    </section>
+  );
+}
+
+function FarmerReport({ report }: { report: FarmerAiReport }) {
+  return (
+    <section className="space-y-4">
+      {report.profile && (
+        <ReportCard title="Farm manager brief">
+          <p>{report.profile.ai_manager_brief || 'Profile brief not yet captured.'}</p>
+          <p className="mt-3 text-sm text-gray-600">
+            Crop: {report.profile.current_crop || 'unknown'} · Stage: {report.profile.current_crop_stage || 'unknown'} · Main issue: {report.profile.primary_pain_point || 'unknown'}
+          </p>
+        </ReportCard>
+      )}
+      <ReportList title="Crop journey" items={report.crop_journey} />
+      <ReportList title="Weekly observation summary" items={report.weekly_observation_summary} />
+      <ReportList title="Advice generated" items={report.advice_summary} />
+      <ReportList title="Follow-up questions" items={report.follow_up_questions} />
+      <ReportList title="Lessons learned" items={report.lessons_learned} />
+      <ReportList title="Next-season recommendations" items={report.next_season_recommendations} />
+      <ReportCard title="Farmer privacy and control">
+        <p>{report.privacy_and_control_statement}</p>
+      </ReportCard>
+    </section>
+  );
+}
+
+function ReportList({ title, items }: { title: string; items: string[] }) {
+  return (
+    <ReportCard title={title}>
+      {items.length === 0 ? (
+        <p className="text-gray-600">No records yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <li key={item} className="border-l-4 border-[#27653a] bg-[#f4f1e8] p-3 text-sm">
+              {item}
+            </li>
+          ))}
+        </ul>
+      )}
+    </ReportCard>
+  );
+}
+
+function ReportCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="border-2 border-black bg-white p-5">
+      <h3 className="text-xl font-black">{title}</h3>
+      <div className="mt-3 leading-relaxed text-gray-700">{children}</div>
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border border-white/40 p-3">
+      <p className="text-xs font-black uppercase text-white/60">{label}</p>
+      <p className="mt-1 text-3xl font-black">{value}</p>
+    </div>
+  );
+}
+
+function eventDot(type: FarmerTimelineEvent['event_type']): string {
+  if (type === 'plan') return 'bg-[#f1d34f]';
+  if (type === 'checkin') return 'bg-[#27653a]';
+  if (type === 'ndani_kit') return 'bg-blue-700';
+  return 'bg-black';
+}
+
+function formatDateTime(epoch: number): string {
+  return new Date(epoch * 1000).toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}

--- a/apps/web/src/screens/VirtualNdani.tsx
+++ b/apps/web/src/screens/VirtualNdani.tsx
@@ -162,6 +162,13 @@ export function VirtualNdani({
               </button>
               <button
                 type="button"
+                onClick={() => navigate('/farm-timeline')}
+                className="border-2 border-white px-5 py-4 text-left font-black text-white hover:bg-white hover:text-black"
+              >
+                Farm timeline and report
+              </button>
+              <button
+                type="button"
                 disabled={starting}
                 onClick={async () => {
                   setStarting(true);


### PR DESCRIPTION
Adds:
Backend:
GET /api/v1/ai-farm-manager/timeline
GET /api/v1/ai-farm-manager/report
deterministic farmer timeline/report service using:AI profile
weekly check-ins
AI plans
recommendation outcomes
Virtual Ndani Kit status


Frontend:
New route: /farm-timeline
New screen: farmer timeline and AI report
Added button on Virtual Ndani Kit dashboard: “Farm timeline and report”

Report includes:
farmer/farm profile summary
crop journey
weekly observation summary
advice generated
follow-up questions
lessons learned
next-season recommendations
physical Ndani Kit readiness
privacy/farmer-control statement

Validation passed:
Backend TypeScript
Backend build
Frontend ESLint
Frontend build