### PR TITLE
Add AI Farm Manager monitoring and evals

### DIFF
--- a/apps/freedom-node/package.json
+++ b/apps/freedom-node/package.json
@@ -11,6 +11,7 @@
     "test": "npm run test:mars && npm run test:agent && npm run test:virtual-ndani",
     "test:mars": "ts-node src/test-mars-scoring.ts",
     "test:agent": "ts-node src/test-agent-foundation.ts",
+    "test:ai-farm-manager:evals": "ts-node src/test-ai-farm-manager-evals.ts",
     "test:agent:integration": "ts-node src/test-agent-integration.ts",
     "test:ai-farm-manager:integration": "ts-node src/test-ai-farm-manager-foundation.ts",
     "test:virtual-ndani": "ts-node src/test-virtual-ndani-foundation.ts",

--- a/apps/freedom-node/src/ai-farm-manager/monitoringService.ts
+++ b/apps/freedom-node/src/ai-farm-manager/monitoringService.ts
@@ -1,0 +1,154 @@
+import { db } from '../database';
+
+export interface AiFarmManagerMonitoringReport {
+  report_version: 'ai-farm-manager-monitoring-v1';
+  generated_at: number;
+  summary: {
+    ai_profiles_completed: number;
+    weekly_checkins_completed: number;
+    ai_plans_generated: number;
+    coordinator_reviews_required: number;
+    recommendations_followed: number;
+    prompt_invocations: number;
+    total_estimated_cost_usd: number;
+    average_cost_per_farmer_usd: number;
+    fallback_rate: number;
+    validation_failure_rate: number;
+  };
+  prompt_families: Array<{
+    prompt_family: string;
+    prompt_version: string;
+    invocations: number;
+    success: number;
+    fallback: number;
+    validation_failed: number;
+    errors: number;
+    estimated_cost_usd: number;
+  }>;
+  common_pain_points: Array<{
+    pain_point: string;
+    farmers: number;
+  }>;
+  recent_failures: Array<{
+    prompt_family: string;
+    prompt_version: string;
+    model_provider: string;
+    model_name: string;
+    status: string;
+    error_code: string | null;
+    created_at: number;
+  }>;
+}
+
+export const aiFarmManagerMonitoringService = {
+  async report(): Promise<AiFarmManagerMonitoringReport> {
+    const [
+      summaryResult,
+      promptFamilyResult,
+      painPointResult,
+      recentFailuresResult,
+    ] = await Promise.all([
+      db.query(`
+        WITH invocation_metrics AS (
+          SELECT
+            COUNT(*)::int AS prompt_invocations,
+            COUNT(DISTINCT farmer_id)::int AS farmers_with_invocations,
+            COALESCE(SUM(estimated_cost_usd), 0)::float AS total_estimated_cost_usd,
+            COALESCE(AVG(CASE WHEN status = 'fallback' THEN 1.0 ELSE 0.0 END), 0)::float AS fallback_rate,
+            COALESCE(AVG(CASE WHEN status = 'validation_failed' THEN 1.0 ELSE 0.0 END), 0)::float AS validation_failure_rate
+          FROM ai_prompt_invocations
+        )
+        SELECT
+          (SELECT COUNT(*)::int FROM farmer_ai_profiles WHERE status IN ('active', 'needs_update')) AS ai_profiles_completed,
+          (SELECT COUNT(*)::int FROM weekly_farm_checkins) AS weekly_checkins_completed,
+          (SELECT COUNT(*)::int FROM ai_farm_plans) AS ai_plans_generated,
+          (SELECT COUNT(*)::int FROM ai_farm_plans WHERE coordinator_review_required = TRUE) AS coordinator_reviews_required,
+          (SELECT COUNT(*)::int FROM ai_recommendation_outcomes WHERE farmer_followed = TRUE) AS recommendations_followed,
+          invocation_metrics.*
+        FROM invocation_metrics
+      `),
+      db.query(`
+        SELECT
+          prompt_family,
+          prompt_version,
+          COUNT(*)::int AS invocations,
+          COUNT(*) FILTER (WHERE status = 'success')::int AS success,
+          COUNT(*) FILTER (WHERE status = 'fallback')::int AS fallback,
+          COUNT(*) FILTER (WHERE status = 'validation_failed')::int AS validation_failed,
+          COUNT(*) FILTER (WHERE status = 'error')::int AS errors,
+          COALESCE(SUM(estimated_cost_usd), 0)::float AS estimated_cost_usd
+        FROM ai_prompt_invocations
+        GROUP BY prompt_family, prompt_version
+        ORDER BY invocations DESC, prompt_family
+      `),
+      db.query(`
+        SELECT primary_pain_point AS pain_point, COUNT(*)::int AS farmers
+        FROM farmer_ai_profiles
+        WHERE primary_pain_point IS NOT NULL
+          AND LENGTH(TRIM(primary_pain_point)) > 0
+          AND status IN ('active', 'needs_update', 'draft')
+        GROUP BY primary_pain_point
+        ORDER BY farmers DESC, primary_pain_point
+        LIMIT 8
+      `),
+      db.query(`
+        SELECT
+          prompt_family,
+          prompt_version,
+          model_provider,
+          model_name,
+          status,
+          error_code,
+          created_at
+        FROM ai_prompt_invocations
+        WHERE status IN ('validation_failed', 'fallback', 'error')
+        ORDER BY created_at DESC
+        LIMIT 10
+      `),
+    ]);
+    const row = summaryResult.rows[0] ?? {};
+    const promptInvocations = Number(row.prompt_invocations ?? 0);
+    const farmersWithInvocations = Number(row.farmers_with_invocations ?? 0);
+    const totalCost = Number(row.total_estimated_cost_usd ?? 0);
+    return {
+      report_version: 'ai-farm-manager-monitoring-v1',
+      generated_at: Math.floor(Date.now() / 1000),
+      summary: {
+        ai_profiles_completed: Number(row.ai_profiles_completed ?? 0),
+        weekly_checkins_completed: Number(row.weekly_checkins_completed ?? 0),
+        ai_plans_generated: Number(row.ai_plans_generated ?? 0),
+        coordinator_reviews_required: Number(row.coordinator_reviews_required ?? 0),
+        recommendations_followed: Number(row.recommendations_followed ?? 0),
+        prompt_invocations: promptInvocations,
+        total_estimated_cost_usd: totalCost,
+        average_cost_per_farmer_usd:
+          farmersWithInvocations > 0 ? totalCost / farmersWithInvocations : 0,
+        fallback_rate: Number(row.fallback_rate ?? 0),
+        validation_failure_rate: Number(row.validation_failure_rate ?? 0),
+      },
+      prompt_families: promptFamilyResult.rows.map((family) => ({
+        prompt_family: family.prompt_family,
+        prompt_version: family.prompt_version,
+        invocations: Number(family.invocations ?? 0),
+        success: Number(family.success ?? 0),
+        fallback: Number(family.fallback ?? 0),
+        validation_failed: Number(family.validation_failed ?? 0),
+        errors: Number(family.errors ?? 0),
+        estimated_cost_usd: Number(family.estimated_cost_usd ?? 0),
+      })),
+      common_pain_points: painPointResult.rows.map((painPoint) => ({
+        pain_point: painPoint.pain_point,
+        farmers: Number(painPoint.farmers ?? 0),
+      })),
+      recent_failures: recentFailuresResult.rows.map((failure) => ({
+        prompt_family: failure.prompt_family,
+        prompt_version: failure.prompt_version,
+        model_provider: failure.model_provider,
+        model_name: failure.model_name,
+        status: failure.status,
+        error_code: failure.error_code,
+        created_at: Number(failure.created_at),
+      })),
+    };
+  },
+};

--- a/apps/freedom-node/src/routes/coordinator.ts
+++ b/apps/freedom-node/src/routes/coordinator.ts
@@ -16,6 +16,7 @@ import {
   AiFarmManagerProfileError,
   coordinatorAiProfileService,
 } from '../ai-farm-manager/coordinatorProfileService';
+import { aiFarmManagerMonitoringService } from '../ai-farm-manager/monitoringService';
 
 const router = Router();
 router.use(requireCoordinator);
@@ -178,6 +179,17 @@ router.get('/metrics', async (_req: FarmerRequest, res) => {
     return res.json({
       success: true,
       metrics: await coordinatorService.metrics(),
+    });
+  } catch (error) {
+    return handleError(error, res);
+  }
+});
+
+router.get('/ai-farm-manager/monitoring', async (_req: FarmerRequest, res) => {
+  try {
+    return res.json({
+      success: true,
+      report: await aiFarmManagerMonitoringService.report(),
     });
   } catch (error) {
     return handleError(error, res);

--- a/apps/freedom-node/src/test-ai-farm-manager-evals.ts
+++ b/apps/freedom-node/src/test-ai-farm-manager-evals.ts
@@ -1,0 +1,228 @@
+import assert from 'assert';
+import { FarmManagerContextPack } from './ai-farm-manager/contextPackService';
+import { FarmManagerChatContextPack } from './ai-farm-manager/chatService';
+import { validateWeeklyPlanOutput } from './ai-farm-manager/weeklyPlanValidation';
+import { validateFarmManagerChatOutput } from './ai-farm-manager/chatValidation';
+
+const now = Math.floor(Date.now() / 1000);
+
+function baseWeeklyPack(): FarmManagerContextPack {
+  return {
+    context_pack_version: 'farm-manager-context-v1',
+    farmer: {
+      farmer_id: 'farmer-001',
+      preferred_language: 'sn-en',
+    },
+    farm: {
+      farm_id: 'farm-001',
+      name: 'Odzi Demo Farm',
+      site_id: 'site-001',
+    },
+    ai_profile: {
+      profile_id: 'profile-001',
+      farmer_id: 'farmer-001',
+      farm_id: 'farm-001',
+      preferred_language: 'sn-en',
+      literacy_level: 'low',
+      technology_comfort: 'low',
+      primary_goal: 'improve tomato yield',
+      primary_pain_point: 'limited water',
+      secondary_pain_points: ['pest scouting'],
+      water_access: 'limited borehole water',
+      irrigation_method: 'bucket irrigation',
+      budget_constraint: 'low budget',
+      labour_constraint: 'family labour only',
+      main_crops: ['tomato'],
+      current_crop: 'tomato',
+      current_crop_stage: 'flowering',
+      soil_type: null,
+      farm_story_summary: 'Farmer has limited water and tomato flowering risk.',
+      ai_manager_brief: 'Tomato flowering, limited water, low budget.',
+      brief_version: 1,
+      status: 'active',
+      created_at: now,
+      updated_at: now,
+    },
+    current_checkin: {
+      checkin_id: 'checkin-001',
+      farmer_id: 'farmer-001',
+      farm_id: 'farm-001',
+      virtual_device_id: 'device-001',
+      week_start: now,
+      crop: 'tomato',
+      crop_stage: 'flowering',
+      soil_condition: 'dry',
+      plant_condition: 'fair',
+      pest_disease_signs: 'none',
+      rain_condition: 'no_recent_rain',
+      irrigation_done: 'no',
+      farmer_biggest_worry: 'plants may dry',
+      labour_or_input_constraint: 'low budget',
+      followed_previous_advice: null,
+      observed_change: null,
+      manual_notes: null,
+      risk_level: 'medium',
+      created_by: 'farmer',
+      created_at: now,
+      updated_at: now,
+    },
+    recent_checkins: [],
+    important_memories: [
+      {
+        memory_id: 'memory-001',
+        farmer_id: 'farmer-001',
+        farm_id: 'farm-001',
+        memory_type: 'constraint',
+        memory_key: 'water',
+        memory_value: 'Limited borehole water',
+        importance: 5,
+        source: 'onboarding',
+        source_id: null,
+        valid_from: now,
+        valid_to: null,
+        created_at: now,
+        updated_at: now,
+      },
+    ],
+    recent_plans: [],
+    agronomy_playbook_snippets: [
+      {
+        key: 'tomato.flowering.water_stress',
+        guidance: 'Tomato flowering is sensitive to water stress.',
+      },
+    ],
+  };
+}
+
+function baseWeeklyOutput(overrides: Record<string, unknown> = {}) {
+  return {
+    risk_level: 'medium',
+    confidence: 'high',
+    farm_status_summary:
+      'Odzi Demo Farm has tomato at flowering stage with dry soil and limited water.',
+    main_issue: 'soil moisture stress',
+    recommended_actions: [
+      {
+        priority: 1,
+        title: 'Protect soil moisture',
+        action: 'Water early morning if water is available and mulch with local material.',
+        reason: 'Tomato flowering is sensitive to water stress.',
+        timeframe: 'Today',
+        cost_level: 'low',
+        difficulty: 'moderate',
+        shona_phrase: 'Chengetedza hunyoro hwevhu.',
+      },
+    ],
+    simple_explanation: 'Dry soil can stress flowering tomatoes.',
+    shona_summary: 'Ivhu rakaoma; chengetedza hunyoro.',
+    follow_up_question: 'How many times can you irrigate before next week?',
+    missing_information: ['soil type'],
+    evidence_used: [
+      {
+        type: 'profile',
+        id: 'profile-001',
+        summary: 'Tomato flowering, limited water, low budget.',
+      },
+      {
+        type: 'checkin',
+        id: 'checkin-001',
+        summary: 'Dry soil and fair plants.',
+      },
+      {
+        type: 'memory',
+        id: 'memory-001',
+        summary: 'Limited borehole water.',
+      },
+    ],
+    coordinator_review_required: false,
+    safety_flags: [],
+    ...overrides,
+  };
+}
+
+function baseChatPack(): FarmManagerChatContextPack {
+  const weekly = baseWeeklyPack();
+  return {
+    context_pack_version: 'farm-manager-chat-context-v1',
+    farmer: weekly.farmer,
+    farm: {
+      farm_id: 'farm-001',
+      name: 'Odzi Demo Farm',
+      site_id: 'site-001',
+    },
+    ai_profile: weekly.ai_profile,
+    recent_checkins: [weekly.current_checkin],
+    important_memories: weekly.important_memories,
+    recent_plans: [],
+    farmer_question: 'What should I do this week?',
+  };
+}
+
+function runWeeklyPlanEvals() {
+  const pack = baseWeeklyPack();
+
+  const valid = validateWeeklyPlanOutput(baseWeeklyOutput(), pack);
+  assert.equal(valid.riskLevel, 'medium');
+  assert.equal(valid.recommendedActions[0].cost_level, 'low');
+  assert.ok(valid.shonaSummary);
+  assert.ok(valid.evidenceUsed.every((item) => (
+    ['profile-001', 'checkin-001', 'memory-001'].includes(item.id)
+  )));
+
+  const severe = validateWeeklyPlanOutput(baseWeeklyOutput({
+    risk_level: 'high',
+    coordinator_review_required: false,
+    safety_flags: ['severe_pest_or_disease_signs'],
+  }), pack);
+  assert.equal(severe.coordinatorReviewRequired, true);
+
+  const unsupportedEvidence = validateWeeklyPlanOutput(baseWeeklyOutput({
+    evidence_used: [
+      { type: 'checkin', id: 'other-farmer-checkin', summary: 'Should be ignored.' },
+      { type: 'checkin', id: 'checkin-001', summary: 'Allowed.' },
+    ],
+  }), pack);
+  assert.deepEqual(unsupportedEvidence.evidenceUsed.map((item) => item.id), ['checkin-001']);
+
+  const sensorClaim = validateWeeklyPlanOutput(baseWeeklyOutput({
+    farm_status_summary: 'The sensor measured dry soil on Odzi Demo Farm.',
+  }), pack);
+  assert.ok(sensorClaim.safetyFlags.some((flag) => flag.includes('sensor_measured')));
+  assert.equal(sensorClaim.coordinatorReviewRequired, true);
+}
+
+function runChatEvals() {
+  const pack = baseChatPack();
+  const chat = validateFarmManagerChatOutput({
+    answer: 'For Odzi Demo Farm, focus on tomato water stress this week.',
+    shona_summary: 'Chengetedza mvura yemadomasi.',
+    recommended_next_step: 'Check soil early morning.',
+    missing_information: [],
+    evidence_used: [
+      { type: 'profile', id: 'profile-001', summary: 'Profile.' },
+      { type: 'checkin', id: 'checkin-001', summary: 'Latest check-in.' },
+    ],
+    confidence: 'high',
+    coordinator_review_required: false,
+    safety_flags: [],
+  }, pack);
+  assert.equal(chat.confidence, 'high');
+  assert.equal(chat.coordinator_review_required, false);
+
+  const chemical = validateFarmManagerChatOutput({
+    answer: 'Do not use pesticide dosage advice without coordinator review.',
+    recommended_next_step: 'Ask the coordinator to inspect the crop.',
+    missing_information: ['pest identity'],
+    evidence_used: [{ type: 'checkin', id: 'checkin-001', summary: 'Latest check-in.' }],
+    confidence: 'medium',
+    coordinator_review_required: false,
+    safety_flags: [],
+  }, pack);
+  assert.equal(chemical.coordinator_review_required, true);
+  assert.ok(chemical.safety_flags.some((flag) => flag.includes('pesticide')));
+}
+
+runWeeklyPlanEvals();
+runChatEvals();
+
+console.log('AI Farm Manager evals passed');

--- a/apps/web/src/agent/api.ts
+++ b/apps/web/src/agent/api.ts
@@ -20,6 +20,7 @@ import type {
   WeeklyFarmCheckinDraft,
   PilotOperationsMetrics,
   PilotEvidenceReport,
+  AiFarmManagerMonitoringReport,
   PhysicalBindingChallenge,
   PhysicalBindingResult,
   PhysicalManualComparison,
@@ -511,6 +512,18 @@ export async function loadCoordinatorEvidenceReport(): Promise<PilotEvidenceRepo
   const body = await response.json() as {
     success: true;
     report: PilotEvidenceReport;
+  };
+  return body.report;
+}
+
+export async function loadAiFarmManagerMonitoring(): Promise<AiFarmManagerMonitoringReport> {
+  const response = await request('/api/v1/coordinator/ai-farm-manager/monitoring', {
+    method: 'GET',
+  });
+  if (!response.ok) throw await toApiError(response);
+  const body = await response.json() as {
+    success: true;
+    report: AiFarmManagerMonitoringReport;
   };
   return body.report;
 }

--- a/apps/web/src/agent/types.ts
+++ b/apps/web/src/agent/types.ts
@@ -292,6 +292,46 @@ export interface PilotEvidenceReport {
   };
 }
 
+export interface AiFarmManagerMonitoringReport {
+  report_version: 'ai-farm-manager-monitoring-v1';
+  generated_at: number;
+  summary: {
+    ai_profiles_completed: number;
+    weekly_checkins_completed: number;
+    ai_plans_generated: number;
+    coordinator_reviews_required: number;
+    recommendations_followed: number;
+    prompt_invocations: number;
+    total_estimated_cost_usd: number;
+    average_cost_per_farmer_usd: number;
+    fallback_rate: number;
+    validation_failure_rate: number;
+  };
+  prompt_families: Array<{
+    prompt_family: string;
+    prompt_version: string;
+    invocations: number;
+    success: number;
+    fallback: number;
+    validation_failed: number;
+    errors: number;
+    estimated_cost_usd: number;
+  }>;
+  common_pain_points: Array<{
+    pain_point: string;
+    farmers: number;
+  }>;
+  recent_failures: Array<{
+    prompt_family: string;
+    prompt_version: string;
+    model_provider: string;
+    model_name: string;
+    status: string;
+    error_code: string | null;
+    created_at: number;
+  }>;
+}
+
 export interface CoordinatorReadingReview extends VirtualNdaniReading {
   device_code: string;
   site_id: string;

--- a/apps/web/src/screens/CoordinatorDashboard.tsx
+++ b/apps/web/src/screens/CoordinatorDashboard.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   downloadCoordinatorEvidenceCsv,
   issuePhysicalBindingChallenge,
+  loadAiFarmManagerMonitoring,
   loadCoordinatorEvidenceReport,
   loadCoordinatorFarmers,
   loadCoordinatorFleet,
@@ -17,6 +18,7 @@ import type {
   CoordinatorFleetDevice,
   CoordinatorFarmer,
   CoordinatorReadingReview,
+  AiFarmManagerMonitoringReport,
   PilotOperationsMetrics,
   PilotEvidenceReport,
   PilotSession,
@@ -41,6 +43,8 @@ export function CoordinatorDashboard({
   const [missedReasons, setMissedReasons] = useState<Record<string, string>>({});
   const [metrics, setMetrics] = useState<PilotOperationsMetrics | null>(null);
   const [evidence, setEvidence] = useState<PilotEvidenceReport | null>(null);
+  const [aiMonitoring, setAiMonitoring] =
+    useState<AiFarmManagerMonitoringReport | null>(null);
   const [downloadingEvidence, setDownloadingEvidence] = useState(false);
   const [bindingDeviceId, setBindingDeviceId] = useState('');
   const [bindingPubkey, setBindingPubkey] = useState('');
@@ -52,18 +56,27 @@ export function CoordinatorDashboard({
   const refresh = useCallback(async () => {
     setError(null);
     await runCoordinatorOperations();
-    const [fleet, pending, operationalMetrics, evidenceReport, enrolledFarmers] = await Promise.all([
+    const [
+      fleet,
+      pending,
+      operationalMetrics,
+      evidenceReport,
+      enrolledFarmers,
+      aiMonitoringReport,
+    ] = await Promise.all([
       loadCoordinatorFleet(),
       loadCoordinatorReviews(),
       loadCoordinatorMetrics(),
       loadCoordinatorEvidenceReport(),
       loadCoordinatorFarmers(),
+      loadAiFarmManagerMonitoring(),
     ]);
     setDevices(fleet);
     setFarmers(enrolledFarmers);
     setReviews(pending);
     setMetrics(operationalMetrics);
     setEvidence(evidenceReport);
+    setAiMonitoring(aiMonitoringReport);
     setReviewStartedAt((current) => {
       const next = { ...current };
       const now = Date.now();
@@ -153,6 +166,85 @@ export function CoordinatorDashboard({
               Physical projections use the configured 30-minute interval. They are estimates,
               not readings that occurred during the pilot.
             </p>
+          </section>
+        )}
+
+        {aiMonitoring && (
+          <section className="mt-7 border-2 border-black bg-white p-5 shadow-[6px_6px_0_#000] sm:p-7">
+            <p className="text-sm font-black uppercase tracking-[0.18em] text-[#27653a]">
+              AI Farm Manager monitoring
+            </p>
+            <h2 className="mt-1 text-3xl font-black">Cost, safety and prompt health</h2>
+            <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <EvidenceFact
+                label="AI profiles completed"
+                value={String(aiMonitoring.summary.ai_profiles_completed)}
+              />
+              <EvidenceFact
+                label="Weekly check-ins"
+                value={String(aiMonitoring.summary.weekly_checkins_completed)}
+              />
+              <EvidenceFact
+                label="AI plans generated"
+                value={String(aiMonitoring.summary.ai_plans_generated)}
+              />
+              <EvidenceFact
+                label="Prompt cost"
+                value={`$${aiMonitoring.summary.total_estimated_cost_usd.toFixed(4)}`}
+                note={`$${aiMonitoring.summary.average_cost_per_farmer_usd.toFixed(4)} avg/farmer`}
+              />
+            </div>
+            <div className="mt-5 grid gap-4 md:grid-cols-3">
+              <MonitorCard
+                label="Fallback rate"
+                value={`${Math.round(aiMonitoring.summary.fallback_rate * 100)}%`}
+                alert={aiMonitoring.summary.fallback_rate > 0.25}
+              />
+              <MonitorCard
+                label="Validation failure rate"
+                value={`${Math.round(aiMonitoring.summary.validation_failure_rate * 100)}%`}
+                alert={aiMonitoring.summary.validation_failure_rate > 0.05}
+              />
+              <MonitorCard
+                label="Coordinator reviews required"
+                value={String(aiMonitoring.summary.coordinator_reviews_required)}
+                alert={aiMonitoring.summary.coordinator_reviews_required > 0}
+              />
+            </div>
+            <div className="mt-6 grid gap-5 lg:grid-cols-2">
+              <div>
+                <h3 className="font-black">Prompt families</h3>
+                {aiMonitoring.prompt_families.length === 0 ? (
+                  <p className="mt-2 text-sm text-gray-600">No prompt invocations recorded yet.</p>
+                ) : (
+                  <ol className="mt-3 space-y-2">
+                    {aiMonitoring.prompt_families.map((family) => (
+                      <li key={`${family.prompt_family}-${family.prompt_version}`} className="border border-black p-3 text-sm">
+                        <p className="font-black">{family.prompt_family} · {family.prompt_version}</p>
+                        <p className="mt-1 text-gray-600">
+                          {family.invocations} calls · {family.success} success · {family.fallback} fallback · ${family.estimated_cost_usd.toFixed(4)}
+                        </p>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+              <div>
+                <h3 className="font-black">Common pain points</h3>
+                {aiMonitoring.common_pain_points.length === 0 ? (
+                  <p className="mt-2 text-sm text-gray-600">No pain points captured yet.</p>
+                ) : (
+                  <ol className="mt-3 space-y-2">
+                    {aiMonitoring.common_pain_points.map((painPoint) => (
+                      <li key={painPoint.pain_point} className="border border-black p-3 text-sm">
+                        <span className="font-black">{painPoint.pain_point}</span>
+                        <span className="ml-2 text-gray-600">({painPoint.farmers} farmers)</span>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+            </div>
           </section>
         )}
 
@@ -669,6 +761,23 @@ function EvidenceFact({
       <p className="text-xs font-black uppercase tracking-wide text-white/65">{label}</p>
       <p className="mt-2 text-2xl font-black">{value}</p>
       {note && <p className="mt-2 text-xs text-white/70">{note}</p>}
+    </article>
+  );
+}
+
+function MonitorCard({
+  label,
+  value,
+  alert = false,
+}: {
+  label: string;
+  value: string;
+  alert?: boolean;
+}) {
+  return (
+    <article className={`border-2 border-black p-4 ${alert ? 'bg-[#f1d34f]' : 'bg-[#f4f1e8]'}`}>
+      <p className="text-xs font-black uppercase tracking-wide text-gray-600">{label}</p>
+      <p className="mt-2 text-3xl font-black">{value}</p>
     </article>
   );
 }


### PR DESCRIPTION
Added coordinator AI Farm Manager monitoring endpoint:
GET /api/v1/coordinator/ai-farm-manager/monitoring

Added coordinator dashboard section showing:
AI profiles completed
weekly check-ins completed
AI plans generated
coordinator reviews required
prompt invocations
estimated Gemini cost
average cost per farmer
fallback rate
validation failure rate
prompt-family breakdown
common farmer pain points

Added fixed AI Farm Manager eval script:
npm run test:ai-farm-manager:evals --workspace @edgechain/freedom-node

The evals check:
valid structured weekly plan output
low-cost recommendation behavior
Shona summary presence
evidence IDs must come from context
severe/risky cases trigger coordinator review
unsupported sensor claims are flagged
pesticide/dosage chat triggers coordinator review
Validation passed:
AI Farm Manager evals
Backend TypeScript
Backend build
Frontend ESLint
Frontend build